### PR TITLE
Change IonDB Unit test code to use the new PlanckUnit changes

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -3,7 +3,10 @@ project(planck_unit)
 
 set(SOURCE_FILES
     planckunit/src/planck_unit.h
-    planckunit/src/planck_unit.c)
+    planckunit/src/planck_unit.c
+    planckunit/src/ion_time/ion_time.c
+    planckunit/src/ion_time/ion_time.h
+        )
 
 if(USE_ARDUINO)
     set(${PROJECT_NAME}_BOARD       ${BOARD})

--- a/src/tests/unit/cpp_wrapper/test_cpp_wrapper.cpp
+++ b/src/tests/unit/cpp_wrapper/test_cpp_wrapper.cpp
@@ -123,8 +123,8 @@ cpp_wrapper_getsuite(
 ) {
 	planck_unit_suite_t *suite = planck_unit_new_suite();
 
-	planck_unit_add_to_suite(suite, test_cpp_wrapper_create_and_destroy);
-	planck_unit_add_to_suite(suite, test_cpp_wrapper_insert_on_all_implementations);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_cpp_wrapper_create_and_destroy);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_cpp_wrapper_insert_on_all_implementations);
 
 	return suite;
 }

--- a/src/tests/unit/dictionary/bpp_tree/test_bpp_tree_handler.c
+++ b/src/tests/unit/dictionary/bpp_tree/test_bpp_tree_handler.c
@@ -120,7 +120,7 @@ bpptreehandler_get_suite(
 ) {
 	planck_unit_suite_t *suite = planck_unit_new_suite();
 
-	planck_unit_add_to_suite(suite, run_bpptreehandler_generic_test_set_1);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, run_bpptreehandler_generic_test_set_1);
 
 	return suite;
 }

--- a/src/tests/unit/dictionary/flat_file/test_flat_file.c
+++ b/src/tests/unit/dictionary/flat_file/test_flat_file.c
@@ -820,16 +820,16 @@ flat_file_getsuite(
 ) {
 	planck_unit_suite_t *suite = planck_unit_new_suite();
 
-	planck_unit_add_to_suite(suite, test_flat_file_initialize);
-	planck_unit_add_to_suite(suite, test_flat_file_simple_insert);
-	planck_unit_add_to_suite(suite, test_flat_file_simple_insert_and_query);
-	planck_unit_add_to_suite(suite, test_flat_file_simple_delete);
-	planck_unit_add_to_suite(suite, test_flat_file_duplicate_insert_1);
-	planck_unit_add_to_suite(suite, test_flat_file_duplicate_insert_2);
-	planck_unit_add_to_suite(suite, test_flat_file_update_1);
-	planck_unit_add_to_suite(suite, test_flat_file_update_2);
-	planck_unit_add_to_suite(suite, test_flat_file_delete_1);
-	planck_unit_add_to_suite(suite, test_flat_file_delete_2);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_initialize);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_simple_insert);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_simple_insert_and_query);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_simple_delete);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_duplicate_insert_1);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_duplicate_insert_2);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_update_1);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_update_2);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_delete_1);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_delete_2);
 
 	return suite;
 }

--- a/src/tests/unit/dictionary/flat_file/test_flat_file_dictionary_handler.c
+++ b/src/tests/unit/dictionary/flat_file/test_flat_file_dictionary_handler.c
@@ -617,17 +617,17 @@ flat_file_handler_getsuite(
 ) {
 	planck_unit_suite_t *suite = planck_unit_new_suite();
 
-	planck_unit_add_to_suite(suite, test_flat_file_handler_function_registration);
-	planck_unit_add_to_suite(suite, test_flat_file_handler_create_destroy);
-	planck_unit_add_to_suite(suite, test_flat_file_handler_simple_insert);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_handler_function_registration);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_handler_create_destroy);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_handler_simple_insert);
 	/* todo need simple query */
-	planck_unit_add_to_suite(suite, test_flat_file_dictionary_predicate_equality);
-	planck_unit_add_to_suite(suite, test_flat_file_dictionary_predicate_range_signed);
-	planck_unit_add_to_suite(suite, test_flat_file_dictionary_predicate_range_unsigned);
-	planck_unit_add_to_suite(suite, test_flat_file_dictionary_cursor_equality);
-	planck_unit_add_to_suite(suite, test_flat_file_dictionary_handler_query_with_results);
-	planck_unit_add_to_suite(suite, test_flat_file_dictionary_handler_query_no_results);
-	planck_unit_add_to_suite(suite, test_flat_file_dictionary_cursor_range);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_dictionary_predicate_equality);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_dictionary_predicate_range_signed);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_dictionary_predicate_range_unsigned);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_dictionary_cursor_equality);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_dictionary_handler_query_with_results);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_dictionary_handler_query_no_results);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_flat_file_dictionary_cursor_range);
 
 	return suite;
 }

--- a/src/tests/unit/dictionary/open_address_file_hash/test_open_address_file_hash.c
+++ b/src/tests/unit/dictionary/open_address_file_hash/test_open_address_file_hash.c
@@ -983,20 +983,20 @@ open_address_file_hashmap_getsuite(
 ) {
 	planck_unit_suite_t *suite = planck_unit_new_suite();
 
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_initialize);
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_compute_simple_hash);
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_get_location);
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_find_item_location);
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_simple_insert);
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_simple_insert_and_query);
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_simple_delete);
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_duplicate_insert_1);
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_duplicate_insert_2);
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_update_1);
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_update_2);
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_delete_1);
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_delete_2);
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_capacity);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_initialize);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_compute_simple_hash);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_get_location);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_find_item_location);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_simple_insert);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_simple_insert_and_query);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_simple_delete);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_duplicate_insert_1);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_duplicate_insert_2);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_update_1);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_update_2);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_delete_1);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_delete_2);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_capacity);
 
 	return suite;
 }

--- a/src/tests/unit/dictionary/open_address_file_hash/test_open_address_file_hash_dictionary_handler.c
+++ b/src/tests/unit/dictionary/open_address_file_hash/test_open_address_file_hash_dictionary_handler.c
@@ -525,15 +525,15 @@ open_address_file_hashmap_handler_getsuite(
 ) {
 	planck_unit_suite_t *suite = planck_unit_new_suite();
 
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_handler_function_registration);
-	planck_unit_add_to_suite(suite, test_open_address_file_hashmap_handler_create_destroy);
-	planck_unit_add_to_suite(suite, test_open_address_file_dictionary_predicate_equality);
-	planck_unit_add_to_suite(suite, test_open_address_file_dictionary_predicate_range_signed);
-	planck_unit_add_to_suite(suite, test_open_address_file_dictionary_predicate_range_unsigned);
-	planck_unit_add_to_suite(suite, test_open_address_file_dictionary_cursor_equality);
-	planck_unit_add_to_suite(suite, test_open_address_file_dictionary_handler_query_with_results);
-	planck_unit_add_to_suite(suite, test_open_address_file_dictionary_handler_query_no_results);
-	planck_unit_add_to_suite(suite, test_open_address_file_dictionary_cursor_range);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_handler_function_registration);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_hashmap_handler_create_destroy);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_dictionary_predicate_equality);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_dictionary_predicate_range_signed);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_dictionary_predicate_range_unsigned);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_dictionary_cursor_equality);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_dictionary_handler_query_with_results);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_dictionary_handler_query_no_results);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_file_dictionary_cursor_range);
 
 	return suite;
 }

--- a/src/tests/unit/dictionary/open_address_hash/test_open_address_hash.c
+++ b/src/tests/unit/dictionary/open_address_hash/test_open_address_hash.c
@@ -978,20 +978,20 @@ open_address_hashmap_getsuite(
 ) {
 	planck_unit_suite_t *suite = planck_unit_new_suite();
 
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_initialize);
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_compute_simple_hash);
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_get_location);
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_find_item_location);
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_simple_insert);
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_simple_insert_and_query);
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_simple_delete);
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_duplicate_insert_1);
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_duplicate_insert_2);
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_update_1);
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_update_2);
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_delete_1);
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_delete_2);
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_capacity);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_initialize);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_compute_simple_hash);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_get_location);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_find_item_location);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_simple_insert);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_simple_insert_and_query);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_simple_delete);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_duplicate_insert_1);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_duplicate_insert_2);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_update_1);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_update_2);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_delete_1);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_delete_2);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_capacity);
 
 	return suite;
 }

--- a/src/tests/unit/dictionary/open_address_hash/test_open_address_hash_dictionary_handler.c
+++ b/src/tests/unit/dictionary/open_address_hash/test_open_address_hash_dictionary_handler.c
@@ -516,15 +516,15 @@ open_address_hashmap_handler_getsuite(
 ) {
 	planck_unit_suite_t *suite = planck_unit_new_suite();
 
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_handler_function_registration);
-	planck_unit_add_to_suite(suite, test_open_address_hashmap_handler_create_destroy);
-	planck_unit_add_to_suite(suite, test_open_address_dictionary_predicate_equality);
-	planck_unit_add_to_suite(suite, test_open_address_dictionary_predicate_range_signed);
-	planck_unit_add_to_suite(suite, test_open_address_dictionary_predicate_range_unsigned);
-	planck_unit_add_to_suite(suite, test_open_address_dictionary_cursor_equality);
-	planck_unit_add_to_suite(suite, test_open_address_dictionary_handler_query_with_results);
-	planck_unit_add_to_suite(suite, test_open_address_dictionary_handler_query_no_results);
-	planck_unit_add_to_suite(suite, test_open_address_dictionary_cursor_range);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_handler_function_registration);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_hashmap_handler_create_destroy);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_dictionary_predicate_equality);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_dictionary_predicate_range_signed);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_dictionary_predicate_range_unsigned);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_dictionary_cursor_equality);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_dictionary_handler_query_with_results);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_dictionary_handler_query_no_results);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_open_address_dictionary_cursor_range);
 
 	return suite;
 }

--- a/src/tests/unit/dictionary/skip_list/test_skip_list.c
+++ b/src/tests/unit/dictionary/skip_list/test_skip_list.c
@@ -1940,57 +1940,57 @@ skiplist_getsuite(
 	planck_unit_suite_t *suite = planck_unit_new_suite();
 
 	/* Initialization Tests */
-	planck_unit_add_to_suite(suite, test_skiplist_initialize);
-	planck_unit_add_to_suite(suite, test_skiplist_free_all);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_initialize);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_free_all);
 
 	/* Insertion Tests */
-	planck_unit_add_to_suite(suite, test_skiplist_single_insert);
-	planck_unit_add_to_suite(suite, test_skiplist_insert_multiple);
-	planck_unit_add_to_suite(suite, test_skiplist_randomized_insert);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_single_insert);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_insert_multiple);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_randomized_insert);
 
 	/* Get Node Tests */
-	planck_unit_add_to_suite(suite, test_skiplist_get_node_single);
-	planck_unit_add_to_suite(suite, test_skiplist_get_node_single_high);
-	planck_unit_add_to_suite(suite, test_skiplist_get_node_single_low);
-	planck_unit_add_to_suite(suite, test_skiplist_get_node_single_many);
-	planck_unit_add_to_suite(suite, test_skiplist_get_node_several);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_get_node_single);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_get_node_single_high);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_get_node_single_low);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_get_node_single_many);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_get_node_several);
 
 	/* Query Tests */
-	planck_unit_add_to_suite(suite, test_skiplist_query_nonexist_empty);
-	planck_unit_add_to_suite(suite, test_skiplist_query_nonexist_populated_single);
-	planck_unit_add_to_suite(suite, test_skiplist_query_nonexist_populated_several);
-	planck_unit_add_to_suite(suite, test_skiplist_query_exist_single);
-	planck_unit_add_to_suite(suite, test_skiplist_query_exist_populated_single);
-	planck_unit_add_to_suite(suite, test_skiplist_query_exist_populated_several);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_query_nonexist_empty);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_query_nonexist_populated_single);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_query_nonexist_populated_several);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_query_exist_single);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_query_exist_populated_single);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_query_exist_populated_several);
 
 	/* Delete Tests */
-	planck_unit_add_to_suite(suite, test_skiplist_delete_empty);
-	planck_unit_add_to_suite(suite, test_skiplist_delete_nonexist_single);
-	planck_unit_add_to_suite(suite, test_skiplist_delete_nonexist_several);
-	planck_unit_add_to_suite(suite, test_skiplist_delete_single);
-	planck_unit_add_to_suite(suite, test_skiplist_delete_single_several);
-	planck_unit_add_to_suite(suite, test_skiplist_delete_single_several_noncont);
-	planck_unit_add_to_suite(suite, test_skiplist_delete_several_all);
-	planck_unit_add_to_suite(suite, test_skiplist_delete_several_same_key);
-	planck_unit_add_to_suite(suite, test_skiplist_delete_several_same_key_in_mix);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_delete_empty);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_delete_nonexist_single);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_delete_nonexist_several);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_delete_single);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_delete_single_several);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_delete_single_several_noncont);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_delete_several_all);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_delete_several_same_key);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_delete_several_same_key_in_mix);
 
 	/* Update Tests */
-	planck_unit_add_to_suite(suite, test_skiplist_update_single_nonexist);
-	planck_unit_add_to_suite(suite, test_skiplist_update_single_nonexist_nonempty);
-	planck_unit_add_to_suite(suite, test_skiplist_update_many_nonexist_nonempty);
-	planck_unit_add_to_suite(suite, test_skiplist_update_single_exist);
-	planck_unit_add_to_suite(suite, test_skiplist_update_single_many_exist);
-	planck_unit_add_to_suite(suite, test_skiplist_update_several_many_exist);
-	planck_unit_add_to_suite(suite, test_skiplist_update_several_same_key);
-	planck_unit_add_to_suite(suite, test_skiplist_update_several_same_key_in_mix);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_update_single_nonexist);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_update_single_nonexist_nonempty);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_update_many_nonexist_nonempty);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_update_single_exist);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_update_single_many_exist);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_update_several_many_exist);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_update_several_same_key);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_update_several_same_key_in_mix);
 
 	/* Hybrid Tests */
-	planck_unit_add_to_suite(suite, test_skiplist_delete_then_insert_single);
-	planck_unit_add_to_suite(suite, test_skiplist_delete_then_insert_several);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_delete_then_insert_single);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_delete_then_insert_several);
 
 	/* Variation Tests */
-	planck_unit_add_to_suite(suite, test_skiplist_different_size);
-	planck_unit_add_to_suite(suite, test_skiplist_big_keys);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_different_size);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_skiplist_big_keys);
 
 	return suite;
 }

--- a/src/tests/unit/dictionary/skip_list/test_skip_list_handler.c
+++ b/src/tests/unit/dictionary/skip_list/test_skip_list_handler.c
@@ -387,17 +387,17 @@ skiplist_handler_getsuite(
 	planck_unit_suite_t *suite = planck_unit_new_suite();
 
 	/* Creation test */
-	planck_unit_add_to_suite(suite, test_collection_handler_binding);
-	planck_unit_add_to_suite(suite, test_collection_creation);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_collection_handler_binding);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_collection_creation);
 
 	/* Cursor Equality test */
-	planck_unit_add_to_suite(suite, test_slhandler_cursor_equality);
-	planck_unit_add_to_suite(suite, test_slhandler_cursor_equality_with_results);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_slhandler_cursor_equality);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_slhandler_cursor_equality_with_results);
 
 	/* Cursor Range test */
-	planck_unit_add_to_suite(suite, test_slhandler_cursor_range);
-	planck_unit_add_to_suite(suite, test_slhandler_cursor_range_with_results);
-	planck_unit_add_to_suite(suite, test_slhandler_cursor_range_lower_missing);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_slhandler_cursor_range);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_slhandler_cursor_range_with_results);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_slhandler_cursor_range_lower_missing);
 
 	return suite;
 }

--- a/src/tests/unit/dictionary/test_dictionary.c
+++ b/src/tests/unit/dictionary/test_dictionary.c
@@ -278,8 +278,8 @@ dictionary_getsuite(
 ) {
 	planck_unit_suite_t *suite = planck_unit_new_suite();
 
-	planck_unit_add_to_suite(suite, test_dictionary_compare_numerics);
-	planck_unit_add_to_suite(suite, test_dictionary_master_table);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_dictionary_compare_numerics);
+	PLANCK_UNIT_ADD_TO_SUITE(suite, test_dictionary_master_table);
 
 	return suite;
 }


### PR DESCRIPTION
All direct calls to planck_unit_add_to_suite() have been updated to the corresponding macro as defined in planckunit.

Added timing information for unit tests, as well as a preamble so that we can figure out how many tests (if any) failed.