### PR TITLE
Fix iinq device build

### DIFF
--- a/src/serial/serial_c_iface.cpp
+++ b/src/serial/serial_c_iface.cpp
@@ -38,7 +38,7 @@ serial_printf_c(
 
 	va_end(args);
 
-	va_start(args);
+	va_start(args, format);
 	vsnprintf(buf, bufsize, format, args);
 	va_end(args);
 

--- a/src/serial/serial_c_iface.cpp
+++ b/src/serial/serial_c_iface.cpp
@@ -29,12 +29,17 @@ serial_printf_c(
 	const char *format,
 	...
 ) {
-	va_list args;
-	int		bufsize = vsnprintf(NULL, 0, format, args);
-	char	buf[bufsize];
+	va_list args, countpass;
 
 	va_start(args, format);
+	va_copy(countpass, args);
+
+	int		bufsize = vsnprintf(NULL, 0, format, countpass);
+	char	buf[bufsize];
+
 	vsnprintf(buf, bufsize, format, args);
+
+	va_end(countpass);
 	va_end(args);
 	return serial_print(buf);
 }

--- a/src/serial/serial_c_iface.cpp
+++ b/src/serial/serial_c_iface.cpp
@@ -29,12 +29,12 @@ serial_printf_c(
 	const char *format,
 	...
 ) {
-	/* Resulting string limited to 512 characters. */
-	char	buf[512];
 	va_list args;
+	int		bufsize = vsnprintf(NULL, 0, format, args);
+	char	buf[bufsize];
 
 	va_start(args, format);
-	vsnprintf(buf, 512, format, args);
+	vsnprintf(buf, bufsize, format, args);
 	va_end(args);
 	return serial_print(buf);
 }

--- a/src/serial/serial_c_iface.cpp
+++ b/src/serial/serial_c_iface.cpp
@@ -33,9 +33,9 @@ serial_printf_c(
 
 	va_start(args, format);
 
-	int bufsize = vsnprintf(NULL, 0, format, args);
 	/* +1 for the null terminator \0 at the end */
-	char buf[bufsize + 1];
+	int		bufsize = vsnprintf(NULL, 0, format, args) + 1;
+	char	buf[bufsize];
 
 	va_end(args);
 

--- a/src/serial/serial_c_iface.cpp
+++ b/src/serial/serial_c_iface.cpp
@@ -29,18 +29,19 @@ serial_printf_c(
 	const char *format,
 	...
 ) {
-	va_list args, countpass;
+	va_list args;
 
 	va_start(args, format);
-	va_copy(countpass, args);
 
-	int		bufsize = vsnprintf(NULL, 0, format, countpass);
+	int		bufsize = vsnprintf(NULL, 0, format, args);
 	char	buf[bufsize];
 
-	vsnprintf(buf, bufsize, format, args);
-
-	va_end(countpass);
 	va_end(args);
+
+	va_start(args);
+	vsnprintf(buf, bufsize, format, args);
+	va_end(args);
+
 	return serial_print(buf);
 }
 

--- a/src/serial/serial_c_iface.cpp
+++ b/src/serial/serial_c_iface.cpp
@@ -33,8 +33,9 @@ serial_printf_c(
 
 	va_start(args, format);
 
-	int		bufsize = vsnprintf(NULL, 0, format, args);
-	char	buf[bufsize];
+	int bufsize = vsnprintf(NULL, 0, format, args);
+	/* +1 for the null terminator \0 at the end */
+	char buf[bufsize + 1];
 
 	va_end(args);
 

--- a/src/tests/behaviour/dictionary/CMakeLists.txt
+++ b/src/tests/behaviour/dictionary/CMakeLists.txt
@@ -12,6 +12,7 @@ if(USE_ARDUINO)
 	set(${PROJECT_NAME}_BOARD       ${BOARD})
 	set(${PROJECT_NAME}_PROCESSOR   ${PROCESSOR})
 	set(${PROJECT_NAME}_MANUAL      ${MANUAL})
+	set(${PROJECT_NAME}_SRCS		${SOURCE_FILES})
 	set(${PROJECT_NAME}_LIBS        planck_unit bpp_tree skip_list flat_file open_address_hash open_address_file_hash)
 
 	generate_arduino_library(${PROJECT_NAME})

--- a/src/tests/unit/dictionary/CMakeLists.txt
+++ b/src/tests/unit/dictionary/CMakeLists.txt
@@ -24,13 +24,13 @@ if(USE_ARDUINO)
         ../../../file/SD_stdio_c_iface.h
         ../../../file/SD_stdio_c_iface.cpp)
 
-    set(${PROJECT_NAME}_LIBS        planck_unit skip_list)
+    set(${PROJECT_NAME}_LIBS        planck_unit bpp_tree)
 
     generate_arduino_firmware(${PROJECT_NAME})
 else()
     add_executable(${PROJECT_NAME}          ${SOURCE_FILES} run_dictionary.c)
 
-    target_link_libraries(${PROJECT_NAME}   planck_unit skip_list)
+    target_link_libraries(${PROJECT_NAME}   planck_unit bpp_tree)
 
     # Use cmake -DCOVERAGE_TESTING=ON to include coverage testing information.
     if (CMAKE_COMPILER_IS_GNUCC AND COVERAGE_TESTING)

--- a/src/tests/unit/dictionary/test_dictionary.c
+++ b/src/tests/unit/dictionary/test_dictionary.c
@@ -194,7 +194,7 @@ test_dictionary_master_table(
 	ion_dictionary_handler_t	handler;
 	ion_dictionary_t			dictionary;
 
-	sldict_init(&handler);
+	bpptree_init(&handler);
 	err = ion_master_table_create_dictionary(&handler, &dictionary, key_type_numeric_signed, sizeof(int), 10, 20);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == err);
@@ -235,7 +235,7 @@ test_dictionary_master_table(
 	ion_dictionary_handler_t	handler2;
 	ion_dictionary_t			dictionary2;
 
-	sldict_init(&handler2);
+	bpptree_init(&handler2);
 	err = ion_master_table_create_dictionary(&handler2, &dictionary2, key_type_numeric_signed, sizeof(short), 7, 14);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == err);

--- a/src/tests/unit/dictionary/test_dictionary.h
+++ b/src/tests/unit/dictionary/test_dictionary.h
@@ -8,7 +8,7 @@
 #include "../../../dictionary/dictionary_types.h"
 #include "./../../../dictionary/dictionary.h"
 #include "./../../../dictionary/ion_master_table.h"
-#include "../../../dictionary/skip_list/skip_list_handler.h"
+#include "../../../dictionary/bpp_tree/bpp_tree_handler.h"
 
 #ifdef  __cplusplus
 extern "C" {

--- a/src/tests/unit/iinq/iinq.ino
+++ b/src/tests/unit/iinq/iinq.ino
@@ -1,0 +1,17 @@
+#include <Arduino.h>
+#include <SPI.h>
+#include <SD.h>
+#include "test_iinq.h"
+
+void
+setup(
+) {
+	SPI.begin();
+	SD.begin(SD_CS_PIN);
+	Serial.begin(BAUD_RATE);
+	run_all_tests_iinq();
+}
+
+void
+loop(
+) {}


### PR DESCRIPTION
Also fixed small things that prevented compilation for device related to the behaviour tests, as well as refactoring the device `printf` implementation to not use a fixed buffer.