### PR TITLE
Casting cleanup

### DIFF
--- a/src/benchmark/ion_bench.ino
+++ b/src/benchmark/ion_bench.ino
@@ -16,7 +16,7 @@
 
 #define SHOW()				printf("%s: ", __func__)
 /**< MAKE_ION_KEY :: int -> ion_key_t (byte*) */
-#define MAKE_ION_KEY(x)		(_keyswap = x, (ion_key_t) &_keyswap)
+#define MAKE_ION_KEY(x)		(_keyswap = x, &_keyswap)
 /**< ION_KEY_TO_INT :: ion_key_t (byte*) -> int */
 #define ION_KEY_TO_INT(key) *((int *) key)
 
@@ -44,7 +44,7 @@ int dict_size				= 10;
 ion_dictionary_t			dict;
 ion_dictionary_handler_t	handler;
 /**< Value payload. */
-ion_value_t test_value = (ion_value_t) (char *) {
+ion_value_t test_value = (char *) {
 	"IonDB Test String"
 };
 /**< Number sequence */
@@ -167,7 +167,7 @@ bench_get(
 		ion_key_t	key = MAKE_ION_KEY(lfsr_get_next(&keygen));
 		char		value[value_size];
 
-		dictionary_get(&dict, key, (ion_value_t) value);
+		dictionary_get(&dict, key, value);
 	}
 
 	benchmark_stop();
@@ -234,8 +234,8 @@ bench_equality(
 		ion_err_t			status = dictionary_find(&dict, &predicate, &cursor);
 		ion_record_t	record;
 
-		record.key		= (ion_key_t) malloc(dict.instance->record.key_size);
-		record.value	= (ion_value_t) malloc(dict.instance->record.value_size);
+		record.key		= malloc(dict.instance->record.key_size);
+		record.value	= malloc(dict.instance->record.value_size);
 
 		while (cursor->next(cursor, &record) != cs_end_of_results) {
 			;
@@ -297,8 +297,8 @@ bench_range(
 		int_upper_bound = max;
 	}
 
-	ion_key_t	lower_bound = (ion_key_t) &int_lower_bound;
-	ion_key_t	upper_bound = (ion_key_t) &int_upper_bound;
+	ion_key_t	lower_bound = &int_lower_bound;
+	ion_key_t	upper_bound = &int_upper_bound;
 
 	benchmark_start();
 
@@ -310,8 +310,8 @@ bench_range(
 	ion_err_t			status = dictionary_find(&dict, &predicate, &cursor);
 	ion_record_t	record;
 
-	record.key		= (ion_key_t) malloc(dict.instance->record.key_size);
-	record.value	= (ion_value_t) malloc(dict.instance->record.value_size);
+	record.key		= malloc(dict.instance->record.key_size);
+	record.value	= malloc(dict.instance->record.value_size);
 
 	while (cursor->next(cursor, &record) != cs_end_of_results) {
 		;

--- a/src/cpp_wrapper/Cursor.h
+++ b/src/cpp_wrapper/Cursor.h
@@ -33,8 +33,8 @@ Cursor(
 	ion_predicate_t		*predicate
 ) {
 	dictionary_find(dictionary, predicate, &cursor);
-	record.key		= (ion_key_t) malloc(dictionary->instance->record.key_size);
-	record.value	= (ion_value_t) malloc(dictionary->instance->record.value_size);
+	record.key		= malloc(dictionary->instance->record.key_size);
+	record.value	= malloc(dictionary->instance->record.value_size);
 }
 
 ~Cursor(

--- a/src/cpp_wrapper/Dictionary.h
+++ b/src/cpp_wrapper/Dictionary.h
@@ -62,8 +62,8 @@ insert(
 	K	key,
 	V	value
 ) {
-	ion_key_t	ion_key		= (ion_key_t) &key;
-	ion_value_t ion_value	= (ion_value_t) &value;
+	ion_key_t	ion_key		= &key;
+	ion_value_t ion_value	= &value;
 
 	ion_status_t status		= dictionary_insert(&dict, ion_key, ion_value);
 
@@ -76,7 +76,7 @@ V
 get(
 	K key
 ) {
-	ion_key_t	ion_key = (ion_key_t) &key;
+	ion_key_t	ion_key = &key;
 	ion_byte_t	ion_value[dict.instance->record.value_size];
 
 	this->last_status = dictionary_get(&dict, ion_key, ion_value);
@@ -95,7 +95,7 @@ ion_status_t
 deleteRecord(
 	K key
 ) {
-	ion_key_t		ion_key = (ion_key_t) &key;
+	ion_key_t		ion_key = &key;
 	ion_status_t	status	= dictionary_delete(&dict, ion_key);
 
 	this->last_status = status;
@@ -117,8 +117,8 @@ update(
 	K	key,
 	V	value
 ) {
-	ion_key_t		ion_key		= (ion_key_t) &key;
-	ion_value_t		ion_value	= (ion_value_t) &value;
+	ion_key_t		ion_key		= &key;
+	ion_value_t		ion_value	= &value;
 	ion_status_t	status		= dictionary_update(&dict, ion_key, ion_value);
 
 	this->last_status = status;
@@ -182,8 +182,8 @@ range(
 	K	max_key
 ) {
 	ion_predicate_t predicate;
-	ion_key_t	ion_min_key = (ion_key_t) &min_key;
-	ion_key_t	ion_max_key = (ion_key_t) &max_key;
+	ion_key_t	ion_min_key = &min_key;
+	ion_key_t	ion_max_key = &max_key;
 
 	dictionary_build_predicate(&predicate, predicate_range, ion_min_key, ion_max_key);
 	return new Cursor<K, V>(&dict, &predicate);
@@ -202,7 +202,7 @@ equality(
 	K key
 ) {
 	ion_predicate_t predicate;
-	ion_key_t	ion_key = (ion_key_t) &key;
+	ion_key_t	ion_key = &key;
 
 	dictionary_build_predicate(&predicate, predicate_equality, ion_key);
 	return new Cursor<K, V>(&dict, &predicate);

--- a/src/dictionary/bpp_tree/bpp_tree.c
+++ b/src/dictionary/bpp_tree/bpp_tree.c
@@ -401,7 +401,7 @@ search(
 	while (lb <= ub) {
 		m		= (lb + ub) / 2;
 		*mkey	= fkey(buf) + ks(m);
-		cc		= h->comp((ion_key_t) key, (ion_key_t) key(*mkey), (ion_key_size_t) (h->keySize));
+		cc		= h->comp(key, key(*mkey), (ion_key_size_t) (h->keySize));
 
 		if ((cc < 0) || ((cc == 0) && (MODE_FGEQ == mode))) {
 			/* key less than key[m] */
@@ -463,11 +463,11 @@ search(
 
 	if (MODE_LLEQ == mode) {
 		*mkey	= fkey(buf) + ks(ub + 1);
-		cc		= h->comp((ion_key_t) key, (ion_key_t) key(*mkey), (ion_key_size_t) (h->keySize));
+		cc		= h->comp(key, key(*mkey), (ion_key_size_t) (h->keySize));
 
 		if ((ub == ct(buf) - 1) || ((ub != -1) && (cc <= 0))) {
 			*mkey	= fkey(buf) + ks(ub);
-			cc		= h->comp((ion_key_t) key, (ion_key_t) key(*mkey), (ion_key_size_t) (h->keySize));
+			cc		= h->comp(key, key(*mkey), (ion_key_size_t) (h->keySize));
 		}
 
 		return cc;
@@ -475,11 +475,11 @@ search(
 
 	if (MODE_FGEQ == mode) {
 		*mkey	= fkey(buf) + ks(lb);
-		cc		= h->comp((ion_key_t) key, (ion_key_t) key(*mkey), (ion_key_size_t) (h->keySize));
+		cc		= h->comp(key, key(*mkey), (ion_key_size_t) (h->keySize));
 
 		if ((lb < ct(buf) - 1) && (cc < 0)) {
 			*mkey	= fkey(buf) + ks(lb + 1);
-			cc		= h->comp((ion_key_t) key, (ion_key_t) key(*mkey), (ion_key_size_t) (h->keySize));
+			cc		= h->comp(key, key(*mkey), (ion_key_size_t) (h->keySize));
 		}
 
 		return cc;
@@ -1167,7 +1167,7 @@ bInsertKey(
 			switch (search(handle, buf, key, rec, &mkey, MODE_MATCH)) {
 				case CC_LT:	/* key < mkey */
 
-					if (!h->dupKeys && (0 != ct(buf)) && (h->comp((ion_key_t) key, (ion_key_t) mkey, (ion_key_size_t) (h->keySize)) == CC_EQ)) {
+					if (!h->dupKeys && (0 != ct(buf)) && (h->comp(key, mkey, (ion_key_size_t) (h->keySize)) == CC_EQ)) {
 						return bErrDupKeys;
 					}
 
@@ -1179,7 +1179,7 @@ bInsertKey(
 
 				case CC_GT:	/* key > mkey */
 
-					if (!h->dupKeys && (h->comp((ion_key_t) key, (ion_key_t) mkey, (ion_key_size_t) (h->keySize)) == CC_EQ)) {
+					if (!h->dupKeys && (h->comp(key, mkey, (ion_key_size_t) (h->keySize)) == CC_EQ)) {
 						return bErrDupKeys;
 					}
 

--- a/src/dictionary/flat_file/flat_file.c
+++ b/src/dictionary/flat_file/flat_file.c
@@ -126,7 +126,7 @@ ff_insert(
 	printf("inserting record of size %i \n", record_size);
 #endif
 
-	if ((record = (ion_f_file_record_t *) malloc(record_size)) == NULL) {
+	if ((record = malloc(record_size)) == NULL) {
 		return ION_STATUS_ERROR(err_out_of_memory);
 	}
 
@@ -175,7 +175,7 @@ ff_insert(
 #endif
 
 			/*if (memcmp(item->data, key, hash_map->record.key_size) == IS_EQUAL)*/
-			if (IS_EQUAL == file->super.compare((ion_key_t) record->data, key, file->super.record.key_size)) {
+			if (IS_EQUAL == file->super.compare(record->data, key, file->super.record.key_size)) {
 				if (wc_insert_unique == file->write_concern) {
 					/* allow unique entries only */
 					free(record);
@@ -235,7 +235,7 @@ ff_find_item_loc(
 
 	ion_f_file_record_t *record;
 
-	if ((record = (ion_f_file_record_t *) malloc(record_size)) == NULL) {
+	if ((record = malloc(record_size)) == NULL) {
 		return err_out_of_memory;
 	}
 
@@ -263,7 +263,7 @@ ff_find_item_loc(
 
 		if (!feof(file->file_ptr) && (DELETED != record->status)) {
 			/*@todo correct compare to use proper return type*/
-			int key_is_equal = file->super.compare((ion_key_t) record->data, key, file->super.record.key_size);
+			int key_is_equal = file->super.compare(record->data, key, file->super.record.key_size);
 
 			if (IS_EQUAL == key_is_equal) {
 				*location = cur_pos;

--- a/src/dictionary/flat_file/flat_file_dictionary_handler.c
+++ b/src/dictionary/flat_file/flat_file_dictionary_handler.c
@@ -127,14 +127,14 @@ ffdict_find(
 	switch (predicate->type) {
 		case predicate_equality: {
 			/* as this is an equality, need to malloc for key as well */
-			if (((*cursor)->predicate->statement.equality.equality_value = malloc((int) (dictionary->instance->record.key_size))) == NULL) {
+			if (((*cursor)->predicate->statement.equality.equality_value = malloc((size_t)(dictionary->instance->record.key_size))) == NULL) {
 				free((*cursor)->predicate);
 				free(*cursor);	/* cleanup */
 				return err_out_of_memory;
 			}
 
 			/* copy across the key value as the predicate may be destroyed */
-			memcpy((*cursor)->predicate->statement.equality.equality_value, predicate->statement.equality.equality_value, (int) (dictionary->instance->record.key_size));
+			memcpy((*cursor)->predicate->statement.equality.equality_value, predicate->statement.equality.equality_value, (size_t)(dictionary->instance->record.key_size));
 
 			/* find the location of the first element as this is a straight equality */
 			ion_fpos_t location = cs_invalid_index;
@@ -167,10 +167,10 @@ ffdict_find(
 			}
 
 			/* copy across the key value as the predicate may be destroyed */
-			memcpy((*cursor)->predicate->statement.range.lower_bound, predicate->statement.range.lower_bound, (int) (dictionary->instance->record.key_size));
+			memcpy((*cursor)->predicate->statement.range.lower_bound, predicate->statement.range.lower_bound, (size_t) (dictionary->instance->record.key_size));
 
 			/* as this is a range, need to malloc upper bound key */
-			if (((*cursor)->predicate->statement.range.upper_bound = malloc((int) (dictionary->instance->record.key_size))) == NULL) {
+			if (((*cursor)->predicate->statement.range.upper_bound = malloc((size_t) (dictionary->instance->record.key_size))) == NULL) {
 				free((*cursor)->predicate->statement.range.lower_bound);
 				free((*cursor)->predicate);
 				free(*cursor);	/* cleanup */
@@ -178,7 +178,7 @@ ffdict_find(
 			}
 
 			/* copy across the key value as the predicate may be destroyed */
-			memcpy((*cursor)->predicate->statement.range.upper_bound, predicate->statement.range.upper_bound, (int) (dictionary->instance->record.key_size));
+			memcpy((*cursor)->predicate->statement.range.upper_bound, predicate->statement.range.upper_bound, (size_t) (dictionary->instance->record.key_size));
 
 			ion_ffdict_cursor_t *ffdict_cursor = (ion_ffdict_cursor_t *) (*cursor);
 

--- a/src/dictionary/flat_file/flat_file_dictionary_handler.c
+++ b/src/dictionary/flat_file/flat_file_dictionary_handler.c
@@ -50,7 +50,7 @@ ffdict_create_dictionary(
 ) {
 	UNUSED(id);
 	UNUSED(dictionary_size);
-	dictionary->instance			= (ion_dictionary_parent_t *) malloc(sizeof(ion_ff_file_t));
+	dictionary->instance			= malloc(sizeof(ion_ff_file_t));
 
 	dictionary->instance->compare	= compare;
 
@@ -105,7 +105,7 @@ ffdict_find(
 	ion_dict_cursor_t	**cursor
 ) {
 	/* allocate memory for cursor */
-	if ((*cursor = (ion_dict_cursor_t *) malloc(sizeof(ion_ffdict_cursor_t))) == NULL) {
+	if ((*cursor = malloc(sizeof(ion_ffdict_cursor_t))) == NULL) {
 		return err_out_of_memory;
 	}
 
@@ -119,7 +119,7 @@ ffdict_find(
 	(*cursor)->next					= ffdict_next;	/* this will use the correct value */
 
 	/* allocate predicate */
-	(*cursor)->predicate			= (ion_predicate_t *) malloc(sizeof(ion_predicate_t));
+	(*cursor)->predicate			= malloc(sizeof(ion_predicate_t));
 	(*cursor)->predicate->type		= predicate->type;
 	(*cursor)->predicate->destroy	= predicate->destroy;
 
@@ -127,7 +127,7 @@ ffdict_find(
 	switch (predicate->type) {
 		case predicate_equality: {
 			/* as this is an equality, need to malloc for key as well */
-			if (((*cursor)->predicate->statement.equality.equality_value = (ion_key_t) malloc((int) (dictionary->instance->record.key_size))) == NULL) {
+			if (((*cursor)->predicate->statement.equality.equality_value = malloc((int) (dictionary->instance->record.key_size))) == NULL) {
 				free((*cursor)->predicate);
 				free(*cursor);	/* cleanup */
 				return err_out_of_memory;
@@ -160,7 +160,7 @@ ffdict_find(
 
 		case predicate_range: {
 			/* as this is a range, need to malloc lower bound key */
-			if (((*cursor)->predicate->statement.range.lower_bound = (ion_key_t) malloc((((ion_ff_file_t *) dictionary->instance)->super.record.key_size))) == NULL) {
+			if (((*cursor)->predicate->statement.range.lower_bound = malloc((((ion_ff_file_t *) dictionary->instance)->super.record.key_size))) == NULL) {
 				free((*cursor)->predicate);
 				free(*cursor);	/* cleanup */
 				return err_out_of_memory;
@@ -361,7 +361,7 @@ ffdict_scan(
 		}
 	}
 
-	if (NULL == (record = (ion_f_file_record_t *) malloc(record_size))) {
+	if (NULL == (record = malloc(record_size))) {
 		return err_out_of_memory;
 	}
 
@@ -372,7 +372,7 @@ ffdict_scan(
 			/**
 			 * Compares value == key
 			 */
-			ion_boolean_t key_satisfies_predicate = ffdict_test_predicate(&(cursor->super), (ion_key_t) record->data);	/* assumes that the key is first */
+			ion_boolean_t key_satisfies_predicate = ffdict_test_predicate(&(cursor->super), record->data);	/* assumes that the key is first */
 
 			if (key_satisfies_predicate == boolean_true) {
 				/*@todo revisit to cache result? */

--- a/src/dictionary/open_address_file_hash/open_address_file_hash.c
+++ b/src/dictionary/open_address_file_hash/open_address_file_hash.c
@@ -134,7 +134,7 @@ oafh_insert(
 
 	int record_size = hash_map->super.record.key_size + hash_map->super.record.value_size + SIZEOF(STATUS);
 
-	item = (ion_hash_bucket_t *) malloc(record_size);
+	item = malloc(record_size);
 
 	/* set file position */
 	fseek(hash_map->file, loc * record_size, SEEK_SET);
@@ -228,7 +228,7 @@ oafh_find_item_loc(
 
 	int record_size = hash_map->super.record.key_size + hash_map->super.record.value_size + SIZEOF(STATUS);
 
-	item = (ion_hash_bucket_t *) malloc(record_size);
+	item = malloc(record_size);
 
 	/* set file position */
 	fseek(hash_map->file, loc * record_size, SEEK_SET);
@@ -290,7 +290,7 @@ oafh_delete(
 
 		int record_size = hash_map->super.record.key_size + hash_map->super.record.value_size + SIZEOF(STATUS);
 
-		item = (ion_hash_bucket_t *) malloc(record_size);
+		item = malloc(record_size);
 
 		/* set file position */
 		fseek(hash_map->file, loc * record_size, SEEK_SET);

--- a/src/dictionary/open_address_file_hash/open_address_file_hash.c
+++ b/src/dictionary/open_address_file_hash/open_address_file_hash.c
@@ -41,7 +41,7 @@ oafh_initialize(
 
 	int record_size = SIZEOF(STATUS) + hashmap->super.record.key_size + hashmap->super.record.value_size;
 
-	file_record			= (ion_hash_bucket_t *) calloc(record_size, 1);
+	file_record			= calloc(record_size, 1);
 	file_record->status = EMPTY;
 
 	/* write out the records to disk to prep */

--- a/src/dictionary/open_address_file_hash/open_address_file_hash_dictionary_handler.c
+++ b/src/dictionary/open_address_file_hash/open_address_file_hash_dictionary_handler.c
@@ -53,7 +53,7 @@ oafdict_create_dictionary(
 ) {
 	UNUSED(id);
 	/* this is the instance of the hashmap */
-	dictionary->instance			= (ion_dictionary_parent_t *) malloc(sizeof(ion_file_hashmap_t));
+	dictionary->instance			= malloc(sizeof(ion_file_hashmap_t));
 
 	dictionary->instance->compare	= compare;
 
@@ -106,7 +106,7 @@ oafdict_find(
 	ion_dict_cursor_t	**cursor
 ) {
 	/* allocate memory for cursor */
-	if ((*cursor = (ion_dict_cursor_t *) malloc(sizeof(ion_oafdict_cursor_t))) == NULL) {
+	if ((*cursor = malloc(sizeof(ion_oafdict_cursor_t))) == NULL) {
 		return err_out_of_memory;
 	}
 
@@ -120,7 +120,7 @@ oafdict_find(
 	(*cursor)->next					= oafdict_next;	/* this will use the correct value */
 
 	/* allocate predicate */
-	(*cursor)->predicate			= (ion_predicate_t *) malloc(sizeof(ion_predicate_t));
+	(*cursor)->predicate			= malloc(sizeof(ion_predicate_t));
 	(*cursor)->predicate->type		= predicate->type;
 	(*cursor)->predicate->destroy	= predicate->destroy;
 
@@ -128,7 +128,7 @@ oafdict_find(
 	switch (predicate->type) {
 		case predicate_equality: {
 			/* as this is an equality, need to malloc for key as well */
-			if (((*cursor)->predicate->statement.equality.equality_value = (ion_key_t) malloc((((ion_file_hashmap_t *) dictionary->instance)->super.record.key_size))) == NULL) {
+			if (((*cursor)->predicate->statement.equality.equality_value = malloc((((ion_file_hashmap_t *) dictionary->instance)->super.record.key_size))) == NULL) {
 				free((*cursor)->predicate);
 				free(*cursor);	/* cleanup */
 				return err_out_of_memory;
@@ -162,7 +162,7 @@ oafdict_find(
 
 		case predicate_range: {
 			/* as this is a range, need to malloc lower bound key */
-			if (((*cursor)->predicate->statement.range.lower_bound = (ion_key_t) malloc((((ion_file_hashmap_t *) dictionary->instance)->super.record.key_size))) == NULL) {
+			if (((*cursor)->predicate->statement.range.lower_bound = malloc((((ion_file_hashmap_t *) dictionary->instance)->super.record.key_size))) == NULL) {
 				free((*cursor)->predicate);
 				free(*cursor);	/* cleanup */
 				return err_out_of_memory;
@@ -172,7 +172,7 @@ oafdict_find(
 			memcpy((*cursor)->predicate->statement.range.lower_bound, predicate->statement.range.lower_bound, (((ion_file_hashmap_t *) dictionary->instance)->super.record.key_size));
 
 			/* as this is a range, need to malloc upper bound key */
-			if (((*cursor)->predicate->statement.range.upper_bound = (ion_key_t) malloc((((ion_file_hashmap_t *) dictionary->instance)->super.record.key_size))) == NULL) {
+			if (((*cursor)->predicate->statement.range.upper_bound = malloc((((ion_file_hashmap_t *) dictionary->instance)->super.record.key_size))) == NULL) {
 				free((*cursor)->predicate->statement.range.lower_bound);
 				free((*cursor)->predicate);
 				free(*cursor);	/* cleanup */
@@ -362,7 +362,7 @@ oafdict_scan(
 
 	ion_hash_bucket_t *item;
 
-	item = (ion_hash_bucket_t *) malloc(record_size);
+	item = malloc(record_size);
 
 	/* start at the current position, scan forward */
 	while (loc != cursor->first) {
@@ -377,7 +377,7 @@ oafdict_scan(
 
 			/* TODO need to check key match; what's the most efficient way? */
 
-			ion_boolean_t key_satisfies_predicate = oafdict_test_predicate(&(cursor->super), (ion_key_t) item->data);	/* assumes that the key is first */
+			ion_boolean_t key_satisfies_predicate = oafdict_test_predicate(&(cursor->super), item->data);	/* assumes that the key is first */
 
 			if (key_satisfies_predicate == boolean_true) {
 				cursor->current = loc;	/* this is the next index for value */

--- a/src/dictionary/open_address_hash/open_address_hash.c
+++ b/src/dictionary/open_address_hash/open_address_hash.c
@@ -35,7 +35,7 @@ oah_initialize(
 
 	/* The hash map is allocated as a single contiguous array*/
 	hashmap->map_size		= size;
-	hashmap->entry			= (void *) malloc((hashmap->super.record.key_size + hashmap->super.record.value_size + 1) * hashmap->map_size);
+	hashmap->entry			= malloc((hashmap->super.record.key_size + hashmap->super.record.value_size + 1) * hashmap->map_size);
 	/* Allows for binding of different hash function depending on requirements. */
 	hashmap->compute_hash	= (*hashing_function);
 
@@ -257,8 +257,8 @@ oah_query(
 		int				data_length = hash_map->super.record.key_size + hash_map->super.record.value_size;
 		ion_hash_bucket_t	*item		= (((ion_hash_bucket_t *) ((hash_map->entry + (data_length + SIZEOF(STATUS)) * loc))));
 
-		/* *value				   = (ion_value_t)malloc(sizeof(char) * (hash_map->super.record.value_size)); */
-		memcpy(value, (ion_value_t) (item->data + hash_map->super.record.key_size), hash_map->super.record.value_size);
+		/* *value				   = malloc(sizeof(char) * (hash_map->super.record.value_size)); */
+		memcpy(value, (item->data + hash_map->super.record.key_size), hash_map->super.record.value_size);
 		return ION_STATUS_OK(1);
 	}
 	else {

--- a/src/dictionary/open_address_hash/open_address_hash_dictionary_handler.c
+++ b/src/dictionary/open_address_hash/open_address_hash_dictionary_handler.c
@@ -52,7 +52,7 @@ oadict_create_dictionary(
 ) {
 	UNUSED(id);
 	/* this is the instance of the hashmap */
-	dictionary->instance			= (ion_dictionary_parent_t *) malloc(sizeof(ion_hashmap_t));
+	dictionary->instance			= malloc(sizeof(ion_hashmap_t));
 
 	dictionary->instance->compare	= compare;
 
@@ -105,7 +105,7 @@ oadict_find(
 	ion_dict_cursor_t	**cursor
 ) {
 	/* allocate memory for cursor */
-	if ((*cursor = (ion_dict_cursor_t *) malloc(sizeof(ion_oadict_cursor_t))) == NULL) {
+	if ((*cursor = malloc(sizeof(ion_oadict_cursor_t))) == NULL) {
 		return err_out_of_memory;
 	}
 
@@ -119,7 +119,7 @@ oadict_find(
 	(*cursor)->next					= oadict_next;	/* this will use the correct value */
 
 	/* allocate predicate */
-	(*cursor)->predicate			= (ion_predicate_t *) malloc(sizeof(ion_predicate_t));
+	(*cursor)->predicate			= malloc(sizeof(ion_predicate_t));
 	(*cursor)->predicate->type		= predicate->type;
 	(*cursor)->predicate->destroy	= predicate->destroy;
 
@@ -127,7 +127,7 @@ oadict_find(
 	switch (predicate->type) {
 		case predicate_equality: {
 			/* as this is an equality, need to malloc for key as well */
-			if (((*cursor)->predicate->statement.equality.equality_value = (ion_key_t) malloc((((ion_hashmap_t *) dictionary->instance)->super.record.key_size))) == NULL) {
+			if (((*cursor)->predicate->statement.equality.equality_value = malloc((((ion_hashmap_t *) dictionary->instance)->super.record.key_size))) == NULL) {
 				free((*cursor)->predicate);
 				free(*cursor);	/* cleanup */
 				return err_out_of_memory;
@@ -160,7 +160,7 @@ oadict_find(
 		}
 
 		case predicate_range: {
-			if (((*cursor)->predicate->statement.range.lower_bound = (ion_key_t) malloc((((ion_hashmap_t *) dictionary->instance)->super.record.key_size))) == NULL) {
+			if (((*cursor)->predicate->statement.range.lower_bound = malloc((((ion_hashmap_t *) dictionary->instance)->super.record.key_size))) == NULL) {
 				free((*cursor)->predicate);
 				free(*cursor);	/* cleanup */
 				return err_out_of_memory;
@@ -170,7 +170,7 @@ oadict_find(
 			memcpy((*cursor)->predicate->statement.range.lower_bound, predicate->statement.range.lower_bound, (((ion_hashmap_t *) dictionary->instance)->super.record.key_size));
 
 			/* as this is a range, need to malloc upper bound key */
-			if (((*cursor)->predicate->statement.range.upper_bound = (ion_key_t) malloc((((ion_hashmap_t *) dictionary->instance)->super.record.key_size))) == NULL) {
+			if (((*cursor)->predicate->statement.range.upper_bound = malloc((((ion_hashmap_t *) dictionary->instance)->super.record.key_size))) == NULL) {
 				free((*cursor)->predicate->statement.range.lower_bound);
 				free((*cursor)->predicate);
 				free(*cursor);	/* cleanup */
@@ -274,9 +274,9 @@ oadict_next(
 		/*@todo A discussion needs to be had regarding ion_record_t and its format in memory etc */
 		/* and copy key and value in */
 
-		memcpy(record->key, (ion_key_t) (item->data), hash_map->super.record.key_size);
+		memcpy(record->key, (item->data), hash_map->super.record.key_size);
 
-		memcpy(record->value, (ion_value_t) (item->data + hash_map->super.record.key_size), hash_map->super.record.value_size);
+		memcpy(record->value, (item->data + hash_map->super.record.key_size), hash_map->super.record.value_size);
 
 		/* and update current cursor position */
 		return cursor->status;
@@ -378,7 +378,7 @@ oadict_scan(
 
 			/* TODO need to check key match; what's the most efficient way? */
 
-			ion_boolean_t key_satisfies_predicate = oadict_test_predicate(&(cursor->super), (ion_key_t) item->data);/* assumes that the key is first */
+			ion_boolean_t key_satisfies_predicate = oadict_test_predicate(&(cursor->super), item->data);/* assumes that the key is first */
 
 			if (key_satisfies_predicate == boolean_true) {
 				cursor->current = loc;	/* this is the next index for value */

--- a/src/key_value/kv_system.h
+++ b/src/key_value/kv_system.h
@@ -65,7 +65,7 @@ typedef unsigned char byte;
 #endif
 /* ===================================================================================== */
 
-#define IONIZE(something, type)		(ion_key_t) &(type) { (something) }
+#define IONIZE(something, type)		&(type) { (something) }
 #define NEUTRALIZE(something, type) (*((type *) (something)))
 #define IONIZE_VAL(varname, size)	ion_byte_t varname[size]
 

--- a/src/tests/unit/dictionary/bpp_tree/test_bpp_tree_handler.c
+++ b/src/tests/unit/dictionary/bpp_tree/test_bpp_tree_handler.c
@@ -41,7 +41,7 @@ run_bpptreehandler_generic_test_set_1(
 			count = 0;
 		}
 
-		dictionary_test_delete(&test, (ion_key_t) (&(to_delete[i])), count, tc);
+		dictionary_test_delete(&test, (&(to_delete[i])), count, tc);
 
 		if (k != -1) {
 			counts[k] = 0;
@@ -63,7 +63,7 @@ run_bpptreehandler_generic_test_set_1(
 		count = 0;
 	}
 
-	dictionary_test_update(&test, (ion_key_t) (&update_key), (ion_value_t) (&update_value), count, tc);
+	dictionary_test_update(&test, (&update_key), (&update_value), count, tc);
 
 	update_key		= 1;
 	update_value	= 12;
@@ -76,7 +76,7 @@ run_bpptreehandler_generic_test_set_1(
 		count = 0;
 	}
 
-	dictionary_test_update(&test, (ion_key_t) (&update_key), (ion_value_t) (&update_value), count, tc);
+	dictionary_test_update(&test, (&update_key), (&update_value), count, tc);
 
 	update_key		= 12;
 	update_value	= 1;
@@ -89,7 +89,7 @@ run_bpptreehandler_generic_test_set_1(
 		count = 0;
 	}
 
-	dictionary_test_update(&test, (ion_key_t) (&update_key), (ion_value_t) (&update_value), count, tc);
+	dictionary_test_update(&test, (&update_key), (&update_value), count, tc);
 
 	dictionary_insert(&test.dictionary, IONIZE(5, int), IONIZE(3, int));
 	dictionary_insert(&test.dictionary, IONIZE(5, int), IONIZE(5, int));

--- a/src/tests/unit/dictionary/flat_file/test_flat_file.c
+++ b/src/tests/unit/dictionary/flat_file/test_flat_file.c
@@ -27,7 +27,7 @@ check_flat_file(
 
 	ion_f_file_record_t *record;
 
-	record = (ion_f_file_record_t *) malloc(bucket_size);
+	record = malloc(bucket_size);
 	DUMP(bucket_size, "%i");
 
 	while (!feof(flat_file->file_ptr)) {
@@ -61,7 +61,7 @@ void
 initialize_flat_file_std_conditions(
 	ion_ff_file_t *flat_file
 ) {
-	ion_record_info_t *record = (ion_record_info_t *) malloc(sizeof(ion_record_info_t));
+	ion_record_info_t *record = malloc(sizeof(ion_record_info_t));
 
 	record->key_size			= sizeof(int);
 	record->value_size			= 10;
@@ -101,7 +101,7 @@ test_flat_file_simple_insert(
 
 		sprintf(str, "%02i is key", i);
 
-		ion_status_t status = ff_insert(&flat_file, (ion_key_t) (&i), (ion_byte_t *) str);	/* this is will wrap */
+		ion_status_t status = ff_insert(&flat_file, (&i), (ion_byte_t *) str);	/* this is will wrap */
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -113,7 +113,7 @@ test_flat_file_simple_insert(
 
 		ion_record_status_t record_status;	/* = ((ion_hash_bucket_t *)(map.entry + ((((i+offset)%map.map_size)*bucket_size )%(map.map_size*bucket_size))))->status; */
 		int					key;		/* = *(int *)(((ion_hash_bucket_t *)(map.entry + ((((i+offset)%map.map_size)*bucket_size )%(map.map_size*bucket_size))))->data ); */
-		ion_byte_t			value[10];		/* = (ion_value_t)(((ion_hash_bucket_t *)(map.entry + ((((i+offset)%map.map_size)*bucket_size )%(map.map_size*bucket_size))))->data + sizeof(int)); */
+		ion_byte_t			value[10];		/* = (((ion_hash_bucket_t *)(map.entry + ((((i+offset)%map.map_size)*bucket_size )%(map.map_size*bucket_size))))->data + sizeof(int)); */
 
 		fread(&record_status, SIZEOF(STATUS), 1, flat_file.file_ptr);
 		fread(&key, flat_file.super.record.key_size, 1, flat_file.file_ptr);
@@ -155,7 +155,7 @@ test_flat_file_simple_insert_and_query(
 
 		sprintf(str, "%02i is key", i);
 
-		ion_status_t status = ff_insert(&flat_file, IONIZE(i, int), (ion_value_t) str);	/* this is will wrap */
+		ion_status_t status = ff_insert(&flat_file, IONIZE(i, int), str);	/* this is will wrap */
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -166,9 +166,9 @@ test_flat_file_simple_insert_and_query(
 	for (i = 0; i < STD_KV_SIZE; i++) {
 		ion_value_t value;
 
-		value = (ion_value_t) malloc(flat_file.super.record.value_size);
+		value = malloc(flat_file.super.record.value_size);
 
-		ion_status_t status = ff_query(&flat_file, (ion_key_t) &i, value);
+		ion_status_t status = ff_query(&flat_file, &i, value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -243,7 +243,7 @@ test_flat_file_simple_delete(
 
 		sprintf(str, "%02i is key", i);
 
-		ion_status_t status = ff_insert(&file, (ion_key_t) (&i), (ion_value_t) str);/* this is will wrap */
+		ion_status_t status = ff_insert(&file, (&i), str);/* this is will wrap */
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -251,18 +251,18 @@ test_flat_file_simple_delete(
 
 	ion_value_t value;
 
-	value = (ion_value_t) malloc(file.super.record.value_size);
+	value = malloc(file.super.record.value_size);
 
 	for (j = 0; j < STD_KV_SIZE; j++) {
 		/* delete the record (single record) */
 		ion_status_t status;
 
-		status = ff_delete(&file, (ion_key_t) (&j));
+		status = ff_delete(&file, (&j));
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
 		/* check to make sure that the record has been deleted */
-		status = ff_query(&file, (ion_key_t) (&j), value);
+		status = ff_query(&file, (&j), value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
@@ -270,9 +270,9 @@ test_flat_file_simple_delete(
 		for (i = j + 1; i < STD_KV_SIZE; i++) {
 			ion_value_t value2;
 
-			value2	= (ion_value_t) malloc(file.super.record.value_size);
+			value2	= malloc(file.super.record.value_size);
 
-			status	= ff_query(&file, (ion_key_t) (&i), value2);
+			status	= ff_query(&file, (&i), value2);
 			PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 			PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -324,7 +324,7 @@ test_flat_file_duplicate_insert_1(
 
 		sprintf(str, "%02i is key", i);
 
-		ion_status_t status = ff_insert(&file, (ion_key_t) (&i), (ion_value_t) str);
+		ion_status_t status = ff_insert(&file, (&i), str);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -338,7 +338,7 @@ test_flat_file_duplicate_insert_1(
 
 		sprintf(str, "%02i is key", i);
 
-		ion_status_t status = ff_insert(&file, (ion_key_t) (&i), (ion_value_t) str);
+		ion_status_t status = ff_insert(&file, (&i), str);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_duplicate_key == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
@@ -380,7 +380,7 @@ test_flat_file_duplicate_insert_2(
 
 		sprintf(str, "%02i is key", i);
 
-		ion_status_t status = ff_insert(&file, (ion_key_t) (&i), (ion_value_t) str);
+		ion_status_t status = ff_insert(&file, (&i), str);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -390,9 +390,9 @@ test_flat_file_duplicate_insert_2(
 	for (i = 0; i < STD_KV_SIZE; i++) {
 		ion_value_t value;
 
-		value = (ion_value_t) malloc(file.super.record.value_size);
+		value = malloc(file.super.record.value_size);
 
-		ion_status_t status = ff_query(&file, (ion_key_t) &i, value);
+		ion_status_t status = ff_query(&file, &i, value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -416,7 +416,7 @@ test_flat_file_duplicate_insert_2(
 
 		sprintf(str, "%02i is new", i);
 
-		ion_status_t status = ff_insert(&file, (ion_key_t) (&i), (ion_value_t) str);
+		ion_status_t status = ff_insert(&file, (&i), str);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -426,9 +426,9 @@ test_flat_file_duplicate_insert_2(
 	for (i = 0; i < STD_KV_SIZE; i++) {
 		ion_value_t value;
 
-		value = (ion_value_t) malloc(file.super.record.value_size);
+		value = malloc(file.super.record.value_size);
 
-		ion_status_t status = ff_query(&file, (ion_key_t) &i, value);
+		ion_status_t status = ff_query(&file, &i, value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -477,7 +477,7 @@ test_flat_file_update_1(
 
 		sprintf(str, "%02i is key", i);
 
-		ion_status_t status = ff_insert(&file, (ion_key_t) (&i), (ion_value_t) str);
+		ion_status_t status = ff_insert(&file, (&i), str);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -487,9 +487,9 @@ test_flat_file_update_1(
 	for (i = 0; i < STD_KV_SIZE; i++) {
 		ion_value_t value;
 
-		value = (ion_value_t) malloc(file.super.record.value_size);
+		value = malloc(file.super.record.value_size);
 
-		ion_status_t status = ff_query(&file, (ion_key_t) &i, value);
+		ion_status_t status = ff_query(&file, &i, value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -513,7 +513,7 @@ test_flat_file_update_1(
 
 		sprintf(str, "%02i is new", i);
 
-		ion_status_t status = ff_update(&file, (ion_key_t) (&i), (ion_value_t) str);
+		ion_status_t status = ff_update(&file, (&i), str);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -523,9 +523,9 @@ test_flat_file_update_1(
 	for (i = 0; i < STD_KV_SIZE; i++) {
 		ion_value_t value;
 
-		value = (ion_value_t) malloc(file.super.record.value_size);
+		value = malloc(file.super.record.value_size);
 
-		ion_status_t status = ff_query(&file, (ion_key_t) &i, value);
+		ion_status_t status = ff_query(&file, &i, value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -575,7 +575,7 @@ test_flat_file_update_2(
 
 		sprintf(str, "%02i is key", i);
 
-		ion_status_t status = ff_insert(&file, (ion_key_t) (&i), (ion_value_t) str);
+		ion_status_t status = ff_insert(&file, (&i), str);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -585,9 +585,9 @@ test_flat_file_update_2(
 	for (i = 0; i < STD_KV_SIZE / 2; i++) {
 		ion_value_t value;
 
-		value = (ion_value_t) malloc(file.super.record.value_size);
+		value = malloc(file.super.record.value_size);
 
-		ion_status_t status = ff_query(&file, (ion_key_t) &i, value);
+		ion_status_t status = ff_query(&file, &i, value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -611,7 +611,7 @@ test_flat_file_update_2(
 
 		sprintf(str, "%02i is new", i);
 
-		ion_status_t status = ff_update(&file, (ion_key_t) (&i), (ion_value_t) str);
+		ion_status_t status = ff_update(&file, (&i), str);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -621,9 +621,9 @@ test_flat_file_update_2(
 	for (i = 0; i < STD_KV_SIZE; i++) {
 		ion_value_t value;
 
-		value = (ion_value_t) malloc(file.super.record.value_size);
+		value = malloc(file.super.record.value_size);
 
-		ion_status_t status = ff_query(&file, (ion_key_t) &i, value);
+		ion_status_t status = ff_query(&file, &i, value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -662,20 +662,20 @@ test_flat_file_delete_1(
 
 	sprintf(str, "%02i is key", i);
 
-	ion_status_t status = ff_insert(&file, (ion_key_t) (&i), (ion_value_t) str);
+	ion_status_t status = ff_insert(&file, (&i), str);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
-	status = ff_delete(&file, (ion_key_t) (&i));
+	status = ff_delete(&file, (&i));
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
 	/* Check that value is not there */
 	ion_value_t value;
 
-	value	= (ion_value_t) malloc(file.super.record.value_size);
-	status	= ff_query(&file, (ion_key_t) (&i), value);
+	value	= malloc(file.super.record.value_size);
+	status	= ff_query(&file, (&i), value);
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
@@ -684,7 +684,7 @@ test_flat_file_delete_1(
 	}
 
 	/* Check that value can not be deleted if it is not there already */
-	status = ff_delete(&file, (ion_key_t) (&i));
+	status = ff_delete(&file, (&i));
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
@@ -720,7 +720,7 @@ test_flat_file_delete_2(
 
 		sprintf(str, "%02i is key", i);
 
-		ion_status_t status = ff_insert(&file, (ion_key_t) (&i), (ion_value_t) str);
+		ion_status_t status = ff_insert(&file, (&i), str);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -730,9 +730,9 @@ test_flat_file_delete_2(
 	for (i = 0; i < STD_KV_SIZE; i++) {
 		ion_value_t value;
 
-		value = (ion_value_t) malloc(file.super.record.value_size);
+		value = malloc(file.super.record.value_size);
 
-		ion_status_t status = ff_query(&file, (ion_key_t) &i, value);
+		ion_status_t status = ff_query(&file, &i, value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -755,7 +755,7 @@ test_flat_file_delete_2(
 		printf("Deleting key: %i \n", i);
 #endif
 
-		ion_status_t status = ff_delete(&file, (ion_key_t) (&i));
+		ion_status_t status = ff_delete(&file, (&i));
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -763,8 +763,8 @@ test_flat_file_delete_2(
 		/* Check that value is not there */
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(file.super.record.value_size);
-		status	= ff_query(&file, (ion_key_t) (&i), value);
+		value	= malloc(file.super.record.value_size);
+		status	= ff_query(&file, (&i), value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
@@ -776,8 +776,8 @@ test_flat_file_delete_2(
 		for (j = 0; j < i; j++) {
 			ion_value_t value;
 
-			value	= (ion_value_t) malloc(file.super.record.value_size);
-			status	= ff_query(&file, (ion_key_t) &j, value);
+			value	= malloc(file.super.record.value_size);
+			status	= ff_query(&file, &j, value);
 			PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 			PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -798,9 +798,9 @@ test_flat_file_delete_2(
 	for (i = 0; i < STD_KV_SIZE; i++) {
 		ion_value_t value;
 
-		value = (ion_value_t) malloc(file.super.record.value_size);
+		value = malloc(file.super.record.value_size);
 
-		ion_status_t status = ff_query(&file, (ion_key_t) &i, value);
+		ion_status_t status = ff_query(&file, &i, value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);

--- a/src/tests/unit/dictionary/flat_file/test_flat_file_dictionary_handler.c
+++ b/src/tests/unit/dictionary/flat_file/test_flat_file_dictionary_handler.c
@@ -38,11 +38,11 @@ createFlatFileTestDictionary(
 	int			i;
 	ion_value_t str;
 
-	str = (ion_value_t) malloc(record->value_size * 2);
+	str = malloc(record->value_size * 2);
 
 	for (i = 0; i < size; i++) {
 		sprintf((char *) str, "value : %i ", i);
-		test_dictionary->handler->insert(test_dictionary, (ion_key_t) &i, str);
+		test_dictionary->handler->insert(test_dictionary, &i, str);
 	}
 
 	free(str);
@@ -155,7 +155,7 @@ test_flat_file_handler_simple_insert(
 
 	sprintf((char *) test_value, "value : %i ", test_key);
 
-	ion_status_t status = test_dictionary.handler->insert(&test_dictionary, (ion_key_t) &test_key, (ion_value_t) test_value);
+	ion_status_t status = test_dictionary.handler->insert(&test_dictionary, &test_key, test_value);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -168,7 +168,7 @@ test_flat_file_handler_simple_insert(
 
 	int record_size = SIZEOF(STATUS) + test_dictionary.instance->record.key_size + test_dictionary.instance->record.value_size;
 
-	file_record = (ion_f_file_record_t *) malloc(sizeof(char) * record_size);
+	file_record = malloc(sizeof(char) * record_size);
 
 	/* read the record_info back and check */
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == fread(file_record, record_size, 1, ((ion_ff_file_t *) test_dictionary.instance)->file_ptr));
@@ -183,7 +183,7 @@ test_flat_file_handler_simple_insert(
 
 	sprintf((char *) test_value, "value : %i ", test_key);
 
-	status = test_dictionary.handler->insert(&test_dictionary, (ion_key_t) &test_key, (ion_value_t) test_value);
+	status = test_dictionary.handler->insert(&test_dictionary, &test_key, test_value);
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -285,15 +285,15 @@ test_flat_file_dictionary_handler_query_with_results(
 	/* user must allocate memory before calling next() */
 	ion_record_t record;
 
-	record.value	= (ion_value_t) malloc(sizeof(ion_value_t) * record_info.value_size);
-	record.key		= (ion_key_t) malloc(sizeof(ion_value_t) * record_info.key_size);
+	record.value	= malloc(record_info.value_size);
+	record.key		= malloc(record_info.key_size);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, cs_cursor_active == cursor->next(cursor, &record));
 
 	/* check that value is correct that has been returned */
 	ion_value_t str;
 
-	str = (ion_value_t) malloc(record_info.value_size * 2);
+	str = malloc(record_info.value_size * 2);
 	sprintf((char *) str, "value : %i ", *(int *) predicate.statement.equality.equality_value);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, IS_EQUAL == memcmp(record.value, str, record_info.value_size));
@@ -347,8 +347,8 @@ test_flat_file_dictionary_handler_query_no_results(
 	/* user must allocate memory before calling next() */
 	ion_record_t record;
 
-	record.key		= (ion_key_t) malloc(sizeof(ion_key_t) * record_info.value_size);
-	record.value	= (ion_value_t) malloc(sizeof(ion_value_t) * record_info.value_size);
+	record.key		= malloc(record_info.value_size);
+	record.value	= malloc(record_info.value_size);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, cs_end_of_results == cursor->next(cursor, &record));
 
@@ -366,7 +366,7 @@ test_flat_file_dictionary_predicate_equality(
 ) {
 	ion_key_t key_under_test;
 
-	key_under_test = (ion_key_t) malloc(sizeof(int));
+	key_under_test = malloc(sizeof(int));
 
 	int				size;
 	ion_record_info_t	record_info;
@@ -383,7 +383,7 @@ test_flat_file_dictionary_predicate_equality(
 
 	ion_dict_cursor_t *cursor;	/* create a new cursor pointer */
 
-	cursor			= (ion_dict_cursor_t *) malloc(sizeof(ion_dict_cursor_t));
+	cursor			= malloc(sizeof(ion_dict_cursor_t));
 	cursor->destroy = ffdict_destroy_cursor;
 
 	/* create a new predicate statement */
@@ -394,16 +394,16 @@ test_flat_file_dictionary_predicate_equality(
 	cursor->dictionary	= &test_dictionary;					/* register test dictionary */
 	cursor->predicate	= &predicate;						/* register predicate */
 
-	memcpy(key_under_test, (ion_key_t) &(int) { 1 }, sizeof(int));
+	memcpy(key_under_test, &(int) { 1 }, sizeof(int));
 
 	/* printf("key %i\n",*(int *)key_under_test); */
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == ffdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { 2 }, sizeof(int));
+	memcpy(key_under_test, &(int) { 2 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == ffdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { -1 }, sizeof(int));
+	memcpy(key_under_test, &(int) { -1 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == ffdict_test_predicate(cursor, key_under_test));
 
@@ -420,7 +420,7 @@ test_flat_file_dictionary_predicate_range_signed(
 ) {
 	ion_key_t key_under_test;
 
-	key_under_test = (ion_key_t) malloc(sizeof(int));
+	key_under_test = malloc(sizeof(int));
 
 	int				size;
 	ion_record_info_t	record_info;
@@ -437,7 +437,7 @@ test_flat_file_dictionary_predicate_range_signed(
 
 	ion_dict_cursor_t *cursor;	/* create a new cursor pointer */
 
-	cursor			= (ion_dict_cursor_t *) malloc(sizeof(ion_dict_cursor_t));
+	cursor			= malloc(sizeof(ion_dict_cursor_t));
 	cursor->destroy = ffdict_destroy_cursor;
 
 	/* create a new predicate statement */
@@ -448,25 +448,25 @@ test_flat_file_dictionary_predicate_range_signed(
 	cursor->dictionary	= &test_dictionary;					/* register test dictionary */
 	cursor->predicate	= &predicate;						/* register predicate */
 
-	memcpy(key_under_test, (ion_key_t) &(int) { 0 }, sizeof(int));
+	memcpy(key_under_test, &(int) { 0 }, sizeof(int));
 
 	/* printf("key %i\n",*(int *)key_under_test); */
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == ffdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { -1 }, sizeof(int));
+	memcpy(key_under_test, &(int) { -1 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == ffdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { 1 }, sizeof(int));
+	memcpy(key_under_test, &(int) { 1 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == ffdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { 2 }, sizeof(int));
+	memcpy(key_under_test, &(int) { 2 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == ffdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { -2 }, sizeof(int));
+	memcpy(key_under_test, &(int) { -2 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == ffdict_test_predicate(cursor, key_under_test));
 
@@ -483,7 +483,7 @@ test_flat_file_dictionary_predicate_range_unsigned(
 ) {
 	ion_key_t key_under_test;
 
-	key_under_test = (ion_key_t) malloc(sizeof(unsigned int));
+	key_under_test = malloc(sizeof(unsigned int));
 
 	int				size;
 	ion_record_info_t	record_info;
@@ -500,7 +500,7 @@ test_flat_file_dictionary_predicate_range_unsigned(
 
 	ion_dict_cursor_t *cursor;	/* create a new cursor pointer */
 
-	cursor			= (ion_dict_cursor_t *) malloc(sizeof(ion_dict_cursor_t));
+	cursor			= malloc(sizeof(ion_dict_cursor_t));
 	cursor->destroy = ffdict_destroy_cursor;
 
 	/* create a new predicate statement */
@@ -511,25 +511,25 @@ test_flat_file_dictionary_predicate_range_unsigned(
 	cursor->dictionary	= &test_dictionary;					/* register test dictionary */
 	cursor->predicate	= &predicate;						/* register predicate */
 
-	memcpy(key_under_test, (ion_key_t) &(unsigned int) { 0 }, sizeof(unsigned int));
+	memcpy(key_under_test, &(unsigned int) { 0 }, sizeof(unsigned int));
 
 	/* printf("key %i\n",*(unsigned int *)key_under_test); */
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == ffdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(unsigned int) { 1 }, sizeof(unsigned int));
+	memcpy(key_under_test, &(unsigned int) { 1 }, sizeof(unsigned int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == ffdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(unsigned int) { 2 }, sizeof(unsigned int));
+	memcpy(key_under_test, &(unsigned int) { 2 }, sizeof(unsigned int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == ffdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(unsigned int) { 3 }, sizeof(unsigned int));
+	memcpy(key_under_test, &(unsigned int) { 3 }, sizeof(unsigned int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == ffdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(unsigned int) { 4 }, sizeof(unsigned int));
+	memcpy(key_under_test, &(unsigned int) { 4 }, sizeof(unsigned int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == ffdict_test_predicate(cursor, key_under_test));
 
@@ -572,8 +572,8 @@ test_flat_file_dictionary_cursor_range(
 	/* user must allocate memory before calling next() */
 	ion_record_t record;
 
-	record.key		= (ion_key_t) malloc(record_info.key_size);
-	record.value	= (ion_value_t) malloc(record_info.value_size);
+	record.key		= malloc(record_info.key_size);
+	record.value	= malloc(record_info.value_size);
 
 	int				result_count = 0;
 	ion_cursor_status_t cursor_status;
@@ -584,7 +584,7 @@ test_flat_file_dictionary_cursor_range(
 		/* check that value is correct that has been returned */
 		ion_value_t str;
 
-		str = (ion_value_t) malloc(record_info.value_size * 2);
+		str = malloc(record_info.value_size * 2);
 		sprintf((char *) str, "value : %i ", (*(int *) predicate.statement.range.lower_bound) + result_count);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, IS_EQUAL == memcmp(record.value, str, record_info.value_size));

--- a/src/tests/unit/dictionary/generic_dictionary_test.h
+++ b/src/tests/unit/dictionary/generic_dictionary_test.h
@@ -13,7 +13,7 @@ extern "C" {
 #include "./../../../dictionary/dictionary.h"
 #include "./../../../dictionary/ion_master_table.h"
 
-#define GTEST_DATA (ion_value_t) "Test data, please ignore! 123 123 abc abc"
+#define GTEST_DATA "Test data, please ignore! 123 123 abc abc"
 
 int
 get_count_index_by_key(

--- a/src/tests/unit/dictionary/open_address_file_hash/test_open_address_file_hash.c
+++ b/src/tests/unit/dictionary/open_address_file_hash/test_open_address_file_hash.c
@@ -29,7 +29,7 @@ check_file_map(
 
 	ion_hash_bucket_t *record;
 
-	record = (ion_hash_bucket_t *) malloc(bucket_size);
+	record = malloc(bucket_size);
 
 	for (i = 0; i < map->map_size; i++) {
 		DUMP(i, "%i");
@@ -124,7 +124,7 @@ test_open_address_file_hashmap_compute_simple_hash(
 	initialize_file_hash_map_std_conditions(&map);
 
 	for (i = 0; i < MAX_HASH_TEST; i++) {
-		PLANCK_UNIT_ASSERT_TRUE(tc, (i % map.map_size) == oafh_compute_simple_hash(&map, (ion_key_t) ((int *) &i), sizeof(i)));
+		PLANCK_UNIT_ASSERT_TRUE(tc, (i % map.map_size) == oafh_compute_simple_hash(&map, ((int *) &i), sizeof(i)));
 	}
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == oafh_destroy(&map));
@@ -175,7 +175,7 @@ test_open_address_file_hashmap_find_item_location(
 	char *item;
 
 	/* manually map out item stucture */
-	item = (char *) malloc(sizeof(char) * (record.key_size + record.value_size + sizeof(char)));
+	item = malloc(sizeof(char) * (record.key_size + record.value_size + sizeof(char)));
 
 	/* manually populate array */
 	ion_hash_bucket_t *item_ptr = (ion_hash_bucket_t *) item;
@@ -224,7 +224,7 @@ test_open_address_file_hashmap_find_item_location(
 		for (i = 0; i < map.map_size; i++) {
 			int location;
 
-			PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == oafh_find_item_loc(&map, (ion_key_t) (&i), &location));
+			PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == oafh_find_item_loc(&map, (&i), &location));
 			/* printf("location %i\n",location); */
 			PLANCK_UNIT_ASSERT_TRUE(tc, (i + offset) % map.map_size == location);
 		}
@@ -267,7 +267,7 @@ test_open_address_file_hashmap_simple_insert(
 			char str[10];
 
 			sprintf(str, "%02i is key", i);
-			status = oafh_insert(&map, (ion_key_t) (&i), (ion_byte_t *) str);	/* this is will wrap */
+			status = oafh_insert(&map, (&i), (ion_byte_t *) str);	/* this is will wrap */
 
 			if ((0 == offset) || (wc_duplicate == map.write_concern)) {
 				PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
@@ -281,7 +281,7 @@ test_open_address_file_hashmap_simple_insert(
 
 			ion_record_status_t record_status;	/* = ((ion_hash_bucket_t *)(map.entry + ((((i+offset)%map.map_size)*bucket_size )%(map.map_size*bucket_size))))->status; */
 			int					key;	/* = *(int *)(((ion_hash_bucket_t *)(map.entry + ((((i+offset)%map.map_size)*bucket_size )%(map.map_size*bucket_size))))->data ); */
-			ion_byte_t			value[10];		/* = (ion_value_t)(((ion_hash_bucket_t *)(map.entry + ((((i+offset)%map.map_size)*bucket_size )%(map.map_size*bucket_size))))->data + sizeof(int)); */
+			ion_byte_t			value[10];		/* = (((ion_hash_bucket_t *)(map.entry + ((((i+offset)%map.map_size)*bucket_size )%(map.map_size*bucket_size))))->data + sizeof(int)); */
 
 			fread(&record_status, SIZEOF(STATUS), 1, map.file);
 			fread(&key, map.super.record.key_size, 1, map.file);
@@ -323,14 +323,14 @@ test_open_address_file_hashmap_simple_insert_and_query(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		oafh_insert(&map, (ion_key_t) (&i), (ion_value_t) str);	/* this is will wrap */
+		oafh_insert(&map, (&i), str);	/* this is will wrap */
 	}
 
 	for (i = 0; i < map.map_size; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(map.super.record.value_size);
-		status	= oafh_query(&map, (ion_key_t) &i, value);
+		value	= malloc(map.super.record.value_size);
+		status	= oafh_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -375,22 +375,22 @@ test_open_address_file_hashmap_simple_delete(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		status = oafh_insert(&map, (ion_key_t) (&i), (ion_value_t) str);/* this is will wrap */
+		status = oafh_insert(&map, (&i), str);/* this is will wrap */
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
 
 	ion_value_t value;
 
-	value = (ion_value_t) malloc(map.super.record.value_size);
+	value = malloc(map.super.record.value_size);
 
 	for (j = 0; j < map.map_size; j++) {
 		/* delete the record */
-		status = oafh_delete(&map, (ion_key_t) (&j));
+		status = oafh_delete(&map, (&j));
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 		/* check to make sure that the record has been deleted */
-		status = oafh_query(&map, (ion_key_t) (&j), value);
+		status = oafh_query(&map, (&j), value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
@@ -398,8 +398,8 @@ test_open_address_file_hashmap_simple_delete(
 		for (i = j + 1; i < map.map_size; i++) {
 			ion_value_t value2;
 
-			value2	= (ion_value_t) malloc(map.super.record.value_size);
-			status	= oafh_query(&map, (ion_key_t) &i, value2);
+			value2	= malloc(map.super.record.value_size);
+			status	= oafh_query(&map, &i, value2);
 			PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 			PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -449,7 +449,7 @@ test_open_address_file_hashmap_duplicate_insert_1(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		status = oafh_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oafh_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -461,7 +461,7 @@ test_open_address_file_hashmap_duplicate_insert_1(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		status = oafh_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oafh_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_duplicate_key == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 	}
@@ -501,7 +501,7 @@ test_open_address_file_hashmap_duplicate_insert_2(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		status = oafh_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oafh_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -510,9 +510,9 @@ test_open_address_file_hashmap_duplicate_insert_2(
 	for (i = 0; i < map.map_size; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(map.super.record.value_size);
+		value	= malloc(map.super.record.value_size);
 
-		status	= oafh_query(&map, (ion_key_t) &i, value);
+		status	= oafh_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -534,7 +534,7 @@ test_open_address_file_hashmap_duplicate_insert_2(
 		char str[10];
 
 		sprintf(str, "%02i is new", i);
-		status = oafh_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oafh_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -543,9 +543,9 @@ test_open_address_file_hashmap_duplicate_insert_2(
 	for (i = 0; i < map.map_size; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(map.super.record.value_size);
+		value	= malloc(map.super.record.value_size);
 
-		status	= oafh_query(&map, (ion_key_t) &i, value);
+		status	= oafh_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -592,7 +592,7 @@ test_open_address_file_hashmap_update_1(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		status = oafh_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oafh_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -603,8 +603,8 @@ test_open_address_file_hashmap_update_1(
 
 		;
 
-		value	= (ion_value_t) malloc(map.super.record.value_size);
-		status	= oafh_query(&map, (ion_key_t) &i, value);
+		value	= malloc(map.super.record.value_size);
+		status	= oafh_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -626,7 +626,7 @@ test_open_address_file_hashmap_update_1(
 		char str[10];
 
 		sprintf(str, "%02i is new", i);
-		status = oafh_update(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oafh_update(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -635,8 +635,8 @@ test_open_address_file_hashmap_update_1(
 	for (i = 0; i < map.map_size; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(map.super.record.value_size);
-		status	= oafh_query(&map, (ion_key_t) &i, value);
+		value	= malloc(map.super.record.value_size);
+		status	= oafh_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -684,7 +684,7 @@ test_open_address_file_hashmap_update_2(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		status = oafh_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oafh_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -693,8 +693,8 @@ test_open_address_file_hashmap_update_2(
 	for (i = 0; i < map.map_size / 2; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(map.super.record.value_size);
-		status	= oafh_query(&map, (ion_key_t) &i, value);
+		value	= malloc(map.super.record.value_size);
+		status	= oafh_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -716,7 +716,7 @@ test_open_address_file_hashmap_update_2(
 		char str[10];
 
 		sprintf(str, "%02i is new", i);
-		status = oafh_update(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oafh_update(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -725,8 +725,8 @@ test_open_address_file_hashmap_update_2(
 	for (i = 0; i < map.map_size; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(map.super.record.value_size);
-		status	= oafh_query(&map, (ion_key_t) &i, value);
+		value	= malloc(map.super.record.value_size);
+		status	= oafh_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -763,19 +763,19 @@ test_open_address_file_hashmap_delete_1(
 	char str[10];
 
 	sprintf(str, "%02i is key", i);
-	status = oafh_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+	status = oafh_insert(&map, (&i), str);
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
-	status = oafh_delete(&map, (ion_key_t) (&i));
+	status = oafh_delete(&map, (&i));
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
 	/* Check that value is not there */
 	ion_value_t value;
 
-	value	= (ion_value_t) malloc(map.super.record.value_size);
-	status	= oafh_query(&map, (ion_key_t) (&i), value);
+	value	= malloc(map.super.record.value_size);
+	status	= oafh_query(&map, (&i), value);
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
@@ -784,7 +784,7 @@ test_open_address_file_hashmap_delete_1(
 	}
 
 	/* Check that value can not be deleted if it is not there already */
-	status = oafh_delete(&map, (ion_key_t) (&i));
+	status = oafh_delete(&map, (&i));
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
@@ -819,7 +819,7 @@ test_open_address_file_hashmap_delete_2(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		status = oafh_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oafh_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -828,8 +828,8 @@ test_open_address_file_hashmap_delete_2(
 	for (i = 0; i < map.map_size; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(map.super.record.value_size);
-		status	= oafh_query(&map, (ion_key_t) &i, value);
+		value	= malloc(map.super.record.value_size);
+		status	= oafh_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -850,15 +850,15 @@ test_open_address_file_hashmap_delete_2(
 #if DEBUG
 		printf("Deleting key: %i \n", i);
 #endif
-		status = oafh_delete(&map, (ion_key_t) (&i));
+		status = oafh_delete(&map, (&i));
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
 		/* Check that value is not there */
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(map.super.record.value_size);
-		status	= oafh_query(&map, (ion_key_t) (&i), value);
+		value	= malloc(map.super.record.value_size);
+		status	= oafh_query(&map, (&i), value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
@@ -870,8 +870,8 @@ test_open_address_file_hashmap_delete_2(
 		for (j = 0; j < i; j++) {
 			ion_value_t value;
 
-			value	= (ion_value_t) malloc(map.super.record.value_size);
-			status	= oafh_query(&map, (ion_key_t) &j, value);
+			value	= malloc(map.super.record.value_size);
+			status	= oafh_query(&map, &j, value);
 			PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 			PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -892,8 +892,8 @@ test_open_address_file_hashmap_delete_2(
 	for (i = 0; i < map.map_size; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(map.super.record.value_size);
-		status	= oafh_query(&map, (ion_key_t) &i, value);
+		value	= malloc(map.super.record.value_size);
+		status	= oafh_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
@@ -928,7 +928,7 @@ test_open_address_file_hashmap_capacity(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		status = oafh_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oafh_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -936,10 +936,10 @@ test_open_address_file_hashmap_capacity(
 	/* check status of <K,V> */
 	ion_value_t value;
 
-	value = (ion_value_t) malloc(map.super.record.value_size);
+	value = malloc(map.super.record.value_size);
 
 	for (i = 0; i < map.map_size; i++) {
-		status = oafh_query(&map, (ion_key_t) &i, value);
+		status = oafh_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -956,14 +956,14 @@ test_open_address_file_hashmap_capacity(
 
 	i		= 11;
 	sprintf(str, "%02i is key", i);
-	status	= oafh_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+	status	= oafh_insert(&map, (&i), str);
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_max_capacity == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
 	/* and check to make sure that the contents has not changed */
 	/* check status of <K,V> */
 	for (i = 0; i < map.map_size; i++) {
-		status = oafh_query(&map, (ion_key_t) &i, value);
+		status = oafh_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 

--- a/src/tests/unit/dictionary/open_address_file_hash/test_open_address_file_hash_dictionary_handler.c
+++ b/src/tests/unit/dictionary/open_address_file_hash/test_open_address_file_hash_dictionary_handler.c
@@ -38,11 +38,11 @@ createFileTestDictionary(
 	int			i;
 	ion_value_t str;
 
-	str = (ion_value_t) malloc(record->value_size);
+	str = malloc(record->value_size);
 
 	for (i = 0; i < size; i++) {
 		sprintf((char *) str, "value : %i", i);
-		test_dictionary->handler->insert(test_dictionary, (ion_key_t) &i, str);
+		test_dictionary->handler->insert(test_dictionary, &i, str);
 	}
 
 	free(str);
@@ -181,15 +181,15 @@ test_open_address_file_dictionary_handler_query_with_results(
 	/* user must allocate memory before calling next() */
 	ion_record_t record;
 
-	record.key		= (ion_key_t) malloc(record_info.key_size);
-	record.value	= (ion_value_t) malloc(record_info.value_size);
+	record.key		= malloc(record_info.key_size);
+	record.value	= malloc(record_info.value_size);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, cs_cursor_active == cursor->next(cursor, &record));
 
 	/* check that value is correct that has been returned */
 	ion_value_t str;
 
-	str = (ion_value_t) malloc(record_info.value_size);
+	str = malloc(record_info.value_size);
 	sprintf((char *) str, "value : %i", *(int *) predicate.statement.equality.equality_value);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, IS_EQUAL == memcmp(record.value, str, record_info.value_size));
@@ -245,8 +245,8 @@ test_open_address_file_dictionary_handler_query_no_results(
 	/* user must allocate memory before calling next() */
 	ion_record_t record;
 
-	record.key		= (ion_key_t) malloc(record_info.key_size);
-	record.value	= (ion_value_t) malloc(record_info.value_size);
+	record.key		= malloc(record_info.key_size);
+	record.value	= malloc(record_info.value_size);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, cs_end_of_results == cursor->next(cursor, &record));
 
@@ -266,7 +266,7 @@ test_open_address_file_dictionary_predicate_equality(
 ) {
 	ion_key_t key_under_test;
 
-	key_under_test = (ion_key_t) malloc(sizeof(int));
+	key_under_test = malloc(sizeof(int));
 
 	int				size;
 	ion_record_info_t	record;
@@ -283,7 +283,7 @@ test_open_address_file_dictionary_predicate_equality(
 
 	ion_dict_cursor_t *cursor;	/* create a new cursor pointer */
 
-	cursor			= (ion_dict_cursor_t *) malloc(sizeof(ion_dict_cursor_t));
+	cursor			= malloc(sizeof(ion_dict_cursor_t));
 	cursor->destroy = oafdict_destroy_cursor;
 
 	/* create a new predicate statement */
@@ -294,17 +294,17 @@ test_open_address_file_dictionary_predicate_equality(
 	cursor->dictionary	= &test_dictionary;					/* register test dictionary */
 	cursor->predicate	= &predicate;						/* register predicate */
 
-	memcpy(key_under_test, (ion_key_t) &(int) { 1 }, sizeof(int));
+	memcpy(key_under_test, &(int) { 1 }, sizeof(int));
 
 	/* printf("key %i\n",*(int *)key_under_test); */
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == oafdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { 2 }, sizeof(int));
+	memcpy(key_under_test, &(int) { 2 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == oafdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { -1 }, sizeof(int));
+	memcpy(key_under_test, &(int) { -1 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == oafdict_test_predicate(cursor, key_under_test));
 
@@ -323,7 +323,7 @@ test_open_address_file_dictionary_predicate_range_signed(
 ) {
 	ion_key_t key_under_test;
 
-	key_under_test = (ion_key_t) malloc(sizeof(int));
+	key_under_test = malloc(sizeof(int));
 
 	int				size;
 	ion_record_info_t	record_info;
@@ -340,7 +340,7 @@ test_open_address_file_dictionary_predicate_range_signed(
 
 	ion_dict_cursor_t *cursor;	/* create a new cursor pointer */
 
-	cursor			= (ion_dict_cursor_t *) malloc(sizeof(ion_dict_cursor_t));
+	cursor			= malloc(sizeof(ion_dict_cursor_t));
 	cursor->destroy = oafdict_destroy_cursor;
 
 	/* create a new predicate statement */
@@ -351,25 +351,25 @@ test_open_address_file_dictionary_predicate_range_signed(
 	cursor->dictionary	= &test_dictionary;					/* register test dictionary */
 	cursor->predicate	= &predicate;						/* register predicate */
 
-	memcpy(key_under_test, (ion_key_t) &(int) { 0 }, sizeof(int));
+	memcpy(key_under_test, &(int) { 0 }, sizeof(int));
 
 	/* DUMP(*(int *)key_under_test,"%i"); */
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == oafdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { -1 }, sizeof(int));
+	memcpy(key_under_test, &(int) { -1 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == oafdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { 1 }, sizeof(int));
+	memcpy(key_under_test, &(int) { 1 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == oafdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { 2 }, sizeof(int));
+	memcpy(key_under_test, &(int) { 2 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == oafdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { -2 }, sizeof(int));
+	memcpy(key_under_test, &(int) { -2 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == oafdict_test_predicate(cursor, key_under_test));
 
@@ -389,7 +389,7 @@ test_open_address_file_dictionary_predicate_range_unsigned(
 ) {
 	ion_key_t key_under_test;
 
-	key_under_test = (ion_key_t) malloc(sizeof(unsigned int));
+	key_under_test = malloc(sizeof(unsigned int));
 
 	int				size;
 	ion_record_info_t	record;
@@ -406,7 +406,7 @@ test_open_address_file_dictionary_predicate_range_unsigned(
 
 	ion_dict_cursor_t *cursor;	/* create a new cursor pointer */
 
-	cursor			= (ion_dict_cursor_t *) malloc(sizeof(ion_dict_cursor_t));
+	cursor			= malloc(sizeof(ion_dict_cursor_t));
 	cursor->destroy = oafdict_destroy_cursor;
 
 	/* create a new predicate statement */
@@ -417,25 +417,25 @@ test_open_address_file_dictionary_predicate_range_unsigned(
 	cursor->dictionary	= &test_dictionary;					/* register test dictionary */
 	cursor->predicate	= &predicate;						/* register predicate */
 
-	memcpy(key_under_test, (ion_key_t) &(unsigned int) { 0 }, sizeof(unsigned int));
+	memcpy(key_under_test, &(unsigned int) { 0 }, sizeof(unsigned int));
 
 	/* printf("key %i\n",*(unsigned int *)key_under_test); */
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == oafdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(unsigned int) { 1 }, sizeof(unsigned int));
+	memcpy(key_under_test, &(unsigned int) { 1 }, sizeof(unsigned int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == oafdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(unsigned int) { 2 }, sizeof(unsigned int));
+	memcpy(key_under_test, &(unsigned int) { 2 }, sizeof(unsigned int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == oafdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(unsigned int) { 3 }, sizeof(unsigned int));
+	memcpy(key_under_test, &(unsigned int) { 3 }, sizeof(unsigned int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == oafdict_test_predicate(cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(unsigned int) { 4 }, sizeof(unsigned int));
+	memcpy(key_under_test, &(unsigned int) { 4 }, sizeof(unsigned int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == oafdict_test_predicate(cursor, key_under_test));
 
@@ -482,8 +482,8 @@ test_open_address_file_dictionary_cursor_range(
 	/* user must allocate memory before calling next() */
 	ion_record_t record;
 
-	record.key		= (ion_key_t) malloc(record_info.key_size);
-	record.value	= (ion_value_t) malloc(record_info.value_size);
+	record.key		= malloc(record_info.key_size);
+	record.value	= malloc(record_info.value_size);
 
 	int				result_count = 0;
 	ion_cursor_status_t cursor_status;
@@ -494,7 +494,7 @@ test_open_address_file_dictionary_cursor_range(
 		/* check that value is correct that has been returned */
 		ion_value_t str;
 
-		str = (ion_value_t) malloc(record_info.value_size);
+		str = malloc(record_info.value_size);
 		sprintf((char *) str, "value : %i", (*(int *) predicate.statement.range.lower_bound) + result_count);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, IS_EQUAL == memcmp(record.value, str, record_info.value_size));

--- a/src/tests/unit/dictionary/open_address_hash/test_open_address_hash.c
+++ b/src/tests/unit/dictionary/open_address_hash/test_open_address_hash.c
@@ -109,7 +109,7 @@ test_open_address_hashmap_compute_simple_hash(
 	initialize_hash_map_std_conditions(&map);
 
 	for (i = 0; i < MAX_HASH_TEST; i++) {
-		PLANCK_UNIT_ASSERT_TRUE(tc, (i % map.map_size) == oah_compute_simple_hash(&map, (ion_key_t) ((int *) &i), sizeof(i)));
+		PLANCK_UNIT_ASSERT_TRUE(tc, (i % map.map_size) == oah_compute_simple_hash(&map, ((int *) &i), sizeof(i)));
 	}
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == oah_destroy(&map));
@@ -160,7 +160,7 @@ test_open_address_hashmap_find_item_location(
 	char *item;
 
 	/* manually map out item stucture */
-	item = (char *) malloc(sizeof(char) * (record.key_size + record.value_size + sizeof(char)));
+	item = malloc(sizeof(char) * (record.key_size + record.value_size + sizeof(char)));
 
 	/* manually populate array */
 	ion_hash_bucket_t	*item_ptr	= (ion_hash_bucket_t *) item;
@@ -179,7 +179,7 @@ test_open_address_hashmap_find_item_location(
 		for (i = 0; i < map.map_size; i++) {
 			item_ptr->status = IN_USE;
 			/* Ensure to use key_size */
-			memcpy(item_ptr->data, (ion_key_t) &i, record.key_size);
+			memcpy(item_ptr->data, &i, record.key_size);
 
 			/* build up the value */
 			char str[10];
@@ -195,7 +195,7 @@ test_open_address_hashmap_find_item_location(
 		for (i = 0; i < map.map_size; i++) {
 			int location;
 
-			PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == oah_find_item_loc(&map, (ion_key_t) (&i), &location));
+			PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == oah_find_item_loc(&map, (&i), &location));
 			PLANCK_UNIT_ASSERT_TRUE(tc, (i + offset) % map.map_size == location);
 		}
 	}
@@ -246,7 +246,7 @@ test_open_address_hashmap_simple_insert(
 
 			sprintf((char *) str, "%02i is key", i);
 
-			ion_status_t status = oah_insert(&map, (ion_key_t) (&i), (ion_value_t) str);/* this is will wrap */
+			ion_status_t status = oah_insert(&map, (&i), str);/* this is will wrap */
 
 			/* FIXME: Why are we inserting inside two loops?!? */
 			if ((offset == 0) || (wc_duplicate == map.write_concern)) {
@@ -257,8 +257,8 @@ test_open_address_hashmap_simple_insert(
 
 		for (i = 0; i < map.map_size; i++) {
 			ion_record_status_t status	= ((ion_hash_bucket_t *) (map.entry + ((((i + offset) % map.map_size) * bucket_size) % (map.map_size * bucket_size))))->status;
-			ion_key_t			key		= (ion_key_t) (((ion_hash_bucket_t *) (map.entry + ((((i + offset) % map.map_size) * bucket_size) % (map.map_size * bucket_size))))->data);
-			ion_value_t			value	= (ion_value_t) (((ion_hash_bucket_t *) (map.entry + ((((i + offset) % map.map_size) * bucket_size) % (map.map_size * bucket_size))))->data + record.key_size);
+			ion_key_t			key		= (((ion_hash_bucket_t *) (map.entry + ((((i + offset) % map.map_size) * bucket_size) % (map.map_size * bucket_size))))->data);
+			ion_value_t			value	= (((ion_hash_bucket_t *) (map.entry + ((((i + offset) % map.map_size) * bucket_size) % (map.map_size * bucket_size))))->data + record.key_size);
 
 			/* build up expected value */
 			ion_byte_t str[10];
@@ -300,17 +300,17 @@ test_open_address_hashmap_simple_insert_and_query(
 
 		sprintf(str, "%02i is key", i);
 		/* this is will wrap the map */
-		status = oah_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oah_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
 
 	ion_value_t value;
 
-	value = (ion_value_t) malloc(10);
+	value = malloc(10);
 
 	for (i = 0; i < map.map_size; i++) {
-		status = oah_query(&map, (ion_key_t) &i, value);
+		status = oah_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -353,7 +353,7 @@ test_open_address_hashmap_simple_delete(
 
 	ion_value_t value;
 
-	value = (ion_value_t) malloc(10);
+	value = malloc(10);
 
 	for (i = 0; i < map.map_size; i++) {
 		/* build up the value */
@@ -361,28 +361,28 @@ test_open_address_hashmap_simple_delete(
 
 		sprintf((char *) str, "%02i is key", i);
 		/* this is will wrap the map*/
-		status = oah_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oah_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
-		status = oah_query(&map, (ion_key_t) (&i), value);
+		status = oah_query(&map, (&i), value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
 
 	i		= 0;
-	status	= oah_query(&map, (ion_key_t) (&i), value);
+	status	= oah_query(&map, (&i), value);
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
 	for (j = 0; j < map.map_size; j++) {
 		/* delete the record */
-		status = oah_delete(&map, (ion_key_t) (&j));
+		status = oah_delete(&map, (&j));
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
 		/* check to make sure that the record has been deleted */
-		status = oah_query(&map, (ion_key_t) (&j), value);
+		status = oah_query(&map, (&j), value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
@@ -391,9 +391,9 @@ test_open_address_hashmap_simple_delete(
 /*
 			ion_value_t value;
 */
-			/*value	 = (ion_value_t)malloc(10);*/
+			/*value	 = malloc(10);*/
 
-			status = oah_query(&map, (ion_key_t) &i, value);
+			status = oah_query(&map, &i, value);
 			PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 			PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -446,7 +446,7 @@ test_open_address_hashmap_duplicate_insert_1(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		status = oah_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oah_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -458,7 +458,7 @@ test_open_address_hashmap_duplicate_insert_1(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		status = oah_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oah_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_duplicate_key == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 	}
@@ -498,7 +498,7 @@ test_open_address_hashmap_duplicate_insert_2(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		status = oah_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oah_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -507,8 +507,8 @@ test_open_address_hashmap_duplicate_insert_2(
 	for (i = 0; i < map.map_size; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(10);
-		status	= oah_query(&map, (ion_key_t) &i, value);
+		value	= malloc(10);
+		status	= oah_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -531,7 +531,7 @@ test_open_address_hashmap_duplicate_insert_2(
 		char str[10];
 
 		sprintf(str, "%02i is new", i);
-		status = oah_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oah_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -540,8 +540,8 @@ test_open_address_hashmap_duplicate_insert_2(
 	for (i = 0; i < map.map_size; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(10);
-		status	= oah_query(&map, (ion_key_t) &i, value);
+		value	= malloc(10);
+		status	= oah_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -588,7 +588,7 @@ test_open_address_hashmap_update_1(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		status = oah_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oah_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -597,8 +597,8 @@ test_open_address_hashmap_update_1(
 	for (i = 0; i < map.map_size; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(10);
-		status	= oah_query(&map, (ion_key_t) &i, value);
+		value	= malloc(10);
+		status	= oah_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -620,7 +620,7 @@ test_open_address_hashmap_update_1(
 		char str[10];
 
 		sprintf(str, "%02i is new", i);
-		status = oah_update(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oah_update(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -629,8 +629,8 @@ test_open_address_hashmap_update_1(
 	for (i = 0; i < map.map_size; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(10);
-		status	= oah_query(&map, (ion_key_t) &i, value);
+		value	= malloc(10);
+		status	= oah_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -678,7 +678,7 @@ test_open_address_hashmap_update_2(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		status = oah_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oah_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -687,8 +687,8 @@ test_open_address_hashmap_update_2(
 	for (i = 0; i < map.map_size / 2; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(10);
-		status	= oah_query(&map, (ion_key_t) &i, value);
+		value	= malloc(10);
+		status	= oah_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -710,7 +710,7 @@ test_open_address_hashmap_update_2(
 		char str[10];
 
 		sprintf(str, "%02i is new", i);
-		status = oah_update(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oah_update(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -719,8 +719,8 @@ test_open_address_hashmap_update_2(
 	for (i = 0; i < map.map_size; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(10);
-		status	= oah_query(&map, (ion_key_t) &i, value);
+		value	= malloc(10);
+		status	= oah_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -757,19 +757,19 @@ test_open_address_hashmap_delete_1(
 	char str[10];
 
 	sprintf(str, "%02i is key", i);
-	status = oah_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+	status = oah_insert(&map, (&i), str);
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
-	status = oah_delete(&map, (ion_key_t) (&i));
+	status = oah_delete(&map, (&i));
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
 	/* Check that value is not there */
 	ion_value_t value;
 
-	value	= (ion_value_t) malloc(10);
-	status	= oah_query(&map, (ion_key_t) (&i), value);
+	value	= malloc(10);
+	status	= oah_query(&map, (&i), value);
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
@@ -778,7 +778,7 @@ test_open_address_hashmap_delete_1(
 	}
 
 	/* Check that value can not be deleted if it is not there already */
-	status = oah_delete(&map, (ion_key_t) (&i));
+	status = oah_delete(&map, (&i));
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
@@ -813,7 +813,7 @@ test_open_address_hashmap_delete_2(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		status = oah_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oah_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -822,8 +822,8 @@ test_open_address_hashmap_delete_2(
 	for (i = 0; i < map.map_size; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(10);
-		status	= oah_query(&map, (ion_key_t) &i, value);
+		value	= malloc(10);
+		status	= oah_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -844,15 +844,15 @@ test_open_address_hashmap_delete_2(
 #if DEBUG
 		printf("Deleting key: %i \n", i);
 #endif
-		status = oah_delete(&map, (ion_key_t) (&i));
+		status = oah_delete(&map, (&i));
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
 		/* Check that value is not there */
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(10);
-		status	= oah_query(&map, (ion_key_t) (&i), value);
+		value	= malloc(10);
+		status	= oah_query(&map, (&i), value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
@@ -864,8 +864,8 @@ test_open_address_hashmap_delete_2(
 		for (j = 0; j < i; j++) {
 			ion_value_t value;
 
-			value	= (ion_value_t) malloc(10);
-			status	= oah_query(&map, (ion_key_t) &j, value);
+			value	= malloc(10);
+			status	= oah_query(&map, &j, value);
 			PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 			PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -886,8 +886,8 @@ test_open_address_hashmap_delete_2(
 	for (i = 0; i < map.map_size; i++) {
 		ion_value_t value;
 
-		value	= (ion_value_t) malloc(10);
-		status	= oah_query(&map, (ion_key_t) &i, value);
+		value	= malloc(10);
+		status	= oah_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
@@ -922,7 +922,7 @@ test_open_address_hashmap_capacity(
 		char str[10];
 
 		sprintf(str, "%02i is key", i);
-		status = oah_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+		status = oah_insert(&map, (&i), str);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -930,10 +930,10 @@ test_open_address_hashmap_capacity(
 	/* check status of <K,V> */
 	ion_value_t value;
 
-	value = (ion_value_t) malloc(10);
+	value = malloc(10);
 
 	for (i = 0; i < map.map_size; i++) {
-		status = oah_query(&map, (ion_key_t) &i, value);
+		status = oah_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -950,7 +950,7 @@ test_open_address_hashmap_capacity(
 
 	i		= 11;
 	sprintf(str, "%02i is key", i);
-	status	= oah_insert(&map, (ion_key_t) (&i), (ion_value_t) str);
+	status	= oah_insert(&map, (&i), str);
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_max_capacity == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
 
@@ -958,7 +958,7 @@ test_open_address_hashmap_capacity(
 	/* check status of <K,V> */
 
 	for (i = 0; i < map.map_size; i++) {
-		status = oah_query(&map, (ion_key_t) &i, value);
+		status = oah_query(&map, &i, value);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 

--- a/src/tests/unit/dictionary/open_address_hash/test_open_address_hash_dictionary_handler.c
+++ b/src/tests/unit/dictionary/open_address_hash/test_open_address_hash_dictionary_handler.c
@@ -38,11 +38,11 @@ createTestDictionary(
 	int			i;
 	ion_value_t str;
 
-	str = (ion_value_t) malloc(record->value_size);
+	str = malloc(record->value_size);
 
 	for (i = 0; i < size; i++) {
 		sprintf((char *) str, "value : %i", i);
-		test_dictionary->handler->insert(test_dictionary, (ion_key_t) &i, str);
+		test_dictionary->handler->insert(test_dictionary, &i, str);
 	}
 
 	free(str);
@@ -183,15 +183,15 @@ test_open_address_dictionary_handler_query_with_results(
 	/* user must allocate memory before calling next() */
 	ion_record_t record;
 
-	record.value	= (ion_value_t) malloc(record_info.value_size);
-	record.key		= (ion_key_t) malloc(record_info.key_size);
+	record.value	= malloc(record_info.value_size);
+	record.key		= malloc(record_info.key_size);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, cs_cursor_active == cursor->next(cursor, &record));
 
 	/* check that value is correct that has been returned */
 	ion_value_t str;
 
-	str = (ion_value_t) malloc(record_info.value_size);
+	str = malloc(record_info.value_size);
 	sprintf((char *) str, "value : %i", *(int *) predicate.statement.equality.equality_value);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, IS_EQUAL == memcmp(record.value, str, record_info.value_size));
@@ -245,8 +245,8 @@ test_open_address_dictionary_handler_query_no_results(
 	/* user must allocate memory before calling next() */
 	ion_record_t record;
 
-	record.value	= (ion_value_t) malloc(record_info.value_size);
-	record.key		= (ion_key_t) malloc(record_info.key_size);
+	record.value	= malloc(record_info.value_size);
+	record.key		= malloc(record_info.key_size);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, cs_end_of_results == cursor->next(cursor, &record));
 
@@ -264,7 +264,7 @@ test_open_address_dictionary_predicate_equality(
 ) {
 	ion_key_t key_under_test;
 
-	key_under_test = (ion_key_t) malloc(sizeof(int));
+	key_under_test = malloc(sizeof(int));
 
 	int				size;
 	ion_record_info_t	record;
@@ -291,17 +291,17 @@ test_open_address_dictionary_predicate_equality(
 	cursor.dictionary	= &test_dictionary;					/* register test dictionary */
 	cursor.predicate	= &predicate;						/* register predicate */
 
-	memcpy(key_under_test, (ion_key_t) &(int) { 1 }, sizeof(int));
+	memcpy(key_under_test, &(int) { 1 }, sizeof(int));
 
 	/* printf("key %i\n",*(int *)key_under_test); */
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == oadict_test_predicate(&cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { 2 }, sizeof(int));
+	memcpy(key_under_test, &(int) { 2 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == oadict_test_predicate(&cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { -1 }, sizeof(int));
+	memcpy(key_under_test, &(int) { -1 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == oadict_test_predicate(&cursor, key_under_test));
 
@@ -319,7 +319,7 @@ test_open_address_dictionary_predicate_range_signed(
 ) {
 	ion_key_t key_under_test;
 
-	key_under_test = (ion_key_t) malloc(sizeof(int));
+	key_under_test = malloc(sizeof(int));
 
 	int				size;
 	ion_record_info_t	record;
@@ -346,25 +346,25 @@ test_open_address_dictionary_predicate_range_signed(
 	cursor.dictionary	= &test_dictionary;					/* register test dictionary */
 	cursor.predicate	= &predicate;						/* register predicate */
 
-	memcpy(key_under_test, (ion_key_t) &(int) { 0 }, sizeof(int));
+	memcpy(key_under_test, &(int) { 0 }, sizeof(int));
 
 	/* printf("key %i\n",*(int *)key_under_test); */
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == oadict_test_predicate(&cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { -1 }, sizeof(int));
+	memcpy(key_under_test, &(int) { -1 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == oadict_test_predicate(&cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { 1 }, sizeof(int));
+	memcpy(key_under_test, &(int) { 1 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == oadict_test_predicate(&cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { 2 }, sizeof(int));
+	memcpy(key_under_test, &(int) { 2 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == oadict_test_predicate(&cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(int) { -2 }, sizeof(int));
+	memcpy(key_under_test, &(int) { -2 }, sizeof(int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == oadict_test_predicate(&cursor, key_under_test));
 
@@ -382,7 +382,7 @@ test_open_address_dictionary_predicate_range_unsigned(
 ) {
 	ion_key_t key_under_test;
 
-	key_under_test = (ion_key_t) malloc(sizeof(unsigned int));
+	key_under_test = malloc(sizeof(unsigned int));
 
 	int				size;
 	ion_record_info_t	record;
@@ -409,25 +409,25 @@ test_open_address_dictionary_predicate_range_unsigned(
 	cursor.dictionary	= &test_dictionary;					/* register test dictionary */
 	cursor.predicate	= &predicate;						/* register predicate */
 
-	memcpy(key_under_test, (ion_key_t) &(unsigned int) { 0 }, sizeof(unsigned int));
+	memcpy(key_under_test, &(unsigned int) { 0 }, sizeof(unsigned int));
 
 	/* printf("key %i\n",*(unsigned int *)key_under_test); */
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == oadict_test_predicate(&cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(unsigned int) { 1 }, sizeof(unsigned int));
+	memcpy(key_under_test, &(unsigned int) { 1 }, sizeof(unsigned int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == oadict_test_predicate(&cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(unsigned int) { 2 }, sizeof(unsigned int));
+	memcpy(key_under_test, &(unsigned int) { 2 }, sizeof(unsigned int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_true == oadict_test_predicate(&cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(unsigned int) { 3 }, sizeof(unsigned int));
+	memcpy(key_under_test, &(unsigned int) { 3 }, sizeof(unsigned int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == oadict_test_predicate(&cursor, key_under_test));
 
-	memcpy(key_under_test, (ion_key_t) &(unsigned int) { 4 }, sizeof(unsigned int));
+	memcpy(key_under_test, &(unsigned int) { 4 }, sizeof(unsigned int));
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, boolean_false == oadict_test_predicate(&cursor, key_under_test));
 
@@ -471,8 +471,8 @@ test_open_address_dictionary_cursor_range(
 	/* user must allocate memory before calling next() */
 	ion_record_t record;
 
-	record.value	= (ion_value_t) malloc(record_info.value_size);
-	record.key		= (ion_key_t) malloc(record_info.key_size);
+	record.value	= malloc(record_info.value_size);
+	record.key		= malloc(record_info.key_size);
 
 	int				result_count = 0;
 	ion_cursor_status_t cursor_status;
@@ -483,7 +483,7 @@ test_open_address_dictionary_cursor_range(
 		/* check that value is correct that has been returned */
 		ion_value_t str;
 
-		str = (ion_value_t) malloc(record_info.value_size);
+		str = malloc(record_info.value_size);
 		sprintf((char *) str, "value : %i", (*(int *) predicate.statement.range.lower_bound) + result_count);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, IS_EQUAL == memcmp(record.value, str, record_info.value_size));

--- a/src/tests/unit/dictionary/skip_list/test_skip_list.c
+++ b/src/tests/unit/dictionary/skip_list/test_skip_list.c
@@ -157,7 +157,7 @@ test_skiplist_single_insert(
 
 	strcpy((char *) value, "single.");
 
-	ion_status_t status = sl_insert(&skiplist, (ion_key_t) &key, value);
+	ion_status_t status = sl_insert(&skiplist, &key, value);
 
 #if DEBUG
 	print_skiplist(&skip_list);
@@ -196,7 +196,7 @@ test_skiplist_insert_multiple(
 	int i;
 
 	for (i = 1; i <= 5; i++) {
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &i, strs[i - 1]);
+		ion_status_t status = sl_insert(&skiplist, &i, strs[i - 1]);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -258,7 +258,7 @@ test_skiplist_randomized_insert(
 	for (i = 0; i < 100; i++) {
 		int key				= rand() % 101;
 
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &key, str);
+		ion_status_t status = sl_insert(&skiplist, &key, str);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -308,13 +308,13 @@ test_skiplist_get_node_single(
 
 	int key				= 3;
 
-	ion_status_t status = sl_insert(&skiplist, (ion_key_t) &key, str);
+	ion_status_t status = sl_insert(&skiplist, &key, str);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
 	int			search	= 3;
-	ion_sl_node_t	*node	= sl_find_node(&skiplist, (ion_key_t) &search);
+	ion_sl_node_t	*node	= sl_find_node(&skiplist, &search);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, node != NULL);
 	PLANCK_UNIT_ASSERT_TRUE(tc, *((int *) node->key) == key);
@@ -350,7 +350,7 @@ test_skiplist_get_node_single_high(
 
 	int key				= 3;
 
-	ion_status_t status = sl_insert(&skiplist, (ion_key_t) &key, str);
+	ion_status_t status = sl_insert(&skiplist, &key, str);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -360,7 +360,7 @@ test_skiplist_get_node_single_high(
 #endif
 
 	int			search	= 10;
-	ion_sl_node_t	*node	= sl_find_node(&skiplist, (ion_key_t) &search);
+	ion_sl_node_t	*node	= sl_find_node(&skiplist, &search);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, *((int *) node->key) == key);
 	PLANCK_UNIT_ASSERT_STR_ARE_EQUAL(tc, (char *) str, (char *) node->value);
@@ -396,7 +396,7 @@ test_skiplist_get_node_single_low(
 
 	int key				= 3;
 
-	ion_status_t status = sl_insert(&skiplist, (ion_key_t) &key, str);
+	ion_status_t status = sl_insert(&skiplist, &key, str);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -406,7 +406,7 @@ test_skiplist_get_node_single_low(
 #endif
 
 	int			search	= 2;
-	ion_sl_node_t	*node	= sl_find_node(&skiplist, (ion_key_t) &search);
+	ion_sl_node_t	*node	= sl_find_node(&skiplist, &search);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, node == skiplist.head);
 
@@ -440,7 +440,7 @@ test_skiplist_get_node_single_many(
 
 	int key				= 25;
 
-	ion_status_t status = sl_insert(&skiplist, (ion_key_t) &key, str);
+	ion_status_t status = sl_insert(&skiplist, &key, str);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -457,7 +457,7 @@ test_skiplist_get_node_single_many(
 			continue;
 		}
 
-		status = sl_insert(&skiplist, (ion_key_t) &i, junk);
+		status = sl_insert(&skiplist, &i, junk);
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
@@ -467,7 +467,7 @@ test_skiplist_get_node_single_many(
 #endif
 
 	int			search	= 25;
-	ion_sl_node_t	*node	= sl_find_node(&skiplist, (ion_key_t) &search);
+	ion_sl_node_t	*node	= sl_find_node(&skiplist, &search);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, *((int *) node->key) == key);
 	PLANCK_UNIT_ASSERT_STR_ARE_EQUAL(tc, (char *) str, (char *) node->value);
@@ -508,7 +508,7 @@ test_skiplist_get_node_several(
 		targets[i] = key;
 		sprintf((char *) buffer, "TEST %d", key);
 
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &key, buffer);
+		ion_status_t status = sl_insert(&skiplist, &key, buffer);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -520,7 +520,7 @@ test_skiplist_get_node_several(
 
 	for (i = 0; i < 50; i++) {
 		int			key		= targets[i];
-		ion_sl_node_t	*node	= sl_find_node(&skiplist, (ion_key_t) &key);
+		ion_sl_node_t	*node	= sl_find_node(&skiplist, &key);
 
 		sprintf((char *) buffer, "TEST %d", key);
 		PLANCK_UNIT_ASSERT_TRUE(tc, *((int *) node->key) == key);
@@ -551,7 +551,7 @@ test_skiplist_query_nonexist_empty(
 	int			key			= 3;
 	ion_byte_t	value[10]	= "NULL";
 
-	ion_status_t status		= sl_query(&skiplist, (ion_key_t) &key, value);
+	ion_status_t status		= sl_query(&skiplist, &key, value);
 
 #if DEBUG
 	print_skiplist(&skip_list);
@@ -588,7 +588,7 @@ test_skiplist_query_nonexist_populated_single(
 
 	strcpy((char *) test_value, "I am test");
 
-	ion_status_t status = sl_insert(&skiplist, (ion_key_t) &test_key, test_value);
+	ion_status_t status = sl_insert(&skiplist, &test_key, test_value);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -600,7 +600,7 @@ test_skiplist_query_nonexist_populated_single(
 	int			key			= 10;
 	ion_byte_t	value[10]	= "NULL";
 
-	status = sl_query(&skiplist, (ion_key_t) &key, value);
+	status = sl_query(&skiplist, &key, value);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
@@ -636,7 +636,7 @@ test_skiplist_query_nonexist_populated_several(
 	for (i = 0; i < 32; i++) {
 		sprintf((char *) test_value, "I am: %d", test_key);
 
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &test_key, test_value);
+		ion_status_t status = sl_insert(&skiplist, &test_key, test_value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -650,7 +650,7 @@ test_skiplist_query_nonexist_populated_several(
 	int			key			= 10;
 	ion_byte_t	value[10]	= "NULL";
 
-	ion_status_t status		= sl_query(&skiplist, (ion_key_t) &key, value);
+	ion_status_t status		= sl_query(&skiplist, &key, value);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_item_not_found == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 0 == status.count);
@@ -683,7 +683,7 @@ test_skiplist_query_exist_single(
 
 	strcpy((char *) test_value, "Find me!");
 
-	ion_status_t status = sl_insert(&skiplist, (ion_key_t) &test_key, test_value);
+	ion_status_t status = sl_insert(&skiplist, &test_key, test_value);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -695,7 +695,7 @@ test_skiplist_query_exist_single(
 	int			key = 11;
 	ion_byte_t	value[10];
 
-	status = sl_query(&skiplist, (ion_key_t) &key, value);
+	status = sl_query(&skiplist, &key, value);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -730,7 +730,7 @@ test_skiplist_query_exist_populated_single(
 	for (i = 0; i < 100; i += 2) {
 		sprintf((char *) test_value, "Find %d", i);
 
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &i, test_value);
+		ion_status_t status = sl_insert(&skiplist, &i, test_value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -743,7 +743,7 @@ test_skiplist_query_exist_populated_single(
 	int			key		= 24;
 	ion_byte_t	value[10];
 
-	ion_status_t status = sl_query(&skiplist, (ion_key_t) &key, value);
+	ion_status_t status = sl_query(&skiplist, &key, value);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -778,7 +778,7 @@ test_skiplist_query_exist_populated_several(
 	for (i = 0; i < 100; i++) {
 		sprintf((char *) test_value, "Find %d", i);
 
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &i, test_value);
+		ion_status_t status = sl_insert(&skiplist, &i, test_value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -794,7 +794,7 @@ test_skiplist_query_exist_populated_several(
 	for (i = 0; i < 100; i++) {
 		sprintf(find_value, "Find %d", i);
 
-		ion_status_t status = sl_query(&skiplist, (ion_key_t) &i, value);
+		ion_status_t status = sl_query(&skiplist, &i, value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -823,7 +823,7 @@ test_skiplist_delete_empty(
 	initialize_skiplist_std_conditions(&skiplist);
 
 	int				key		= 3;
-	ion_status_t	status	= sl_delete(&skiplist, (ion_key_t) &key);
+	ion_status_t	status	= sl_delete(&skiplist, &key);
 
 #if DEBUG
 	print_skiplist(&skip_list);
@@ -859,14 +859,14 @@ test_skiplist_delete_nonexist_single(
 
 	strcpy((char *) value, "Delete me");
 
-	ion_status_t status = sl_insert(&skiplist, (ion_key_t) &key, value);
+	ion_status_t status = sl_insert(&skiplist, &key, value);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
 	int fake_key = 33;
 
-	status = sl_delete(&skiplist, (ion_key_t) &fake_key);
+	status = sl_delete(&skiplist, &fake_key);
 
 #if DEBUG
 	print_skiplist(&skip_list);
@@ -905,7 +905,7 @@ test_skiplist_delete_nonexist_several(
 	int i;
 
 	for (i = 0; i < 10; i++) {
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &key, value);
+		ion_status_t status = sl_insert(&skiplist, &key, value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -914,7 +914,7 @@ test_skiplist_delete_nonexist_several(
 	}
 
 	int				fake_key	= 20;
-	ion_status_t	status		= sl_delete(&skiplist, (ion_key_t) &fake_key);
+	ion_status_t	status		= sl_delete(&skiplist, &fake_key);
 
 #if DEBUG
 	print_skiplist(&skip_list);
@@ -950,7 +950,7 @@ test_skiplist_delete_single(
 
 	strcpy((char *) value, "Special K");
 
-	ion_status_t status = sl_insert(&skiplist, (ion_key_t) &key, value);
+	ion_status_t status = sl_insert(&skiplist, &key, value);
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -960,7 +960,7 @@ test_skiplist_delete_single(
 	print_skiplist(&skip_list);
 #endif
 
-	status = sl_delete(&skiplist, (ion_key_t) &key);
+	status = sl_delete(&skiplist, &key);
 
 #if DEBUG
 	printf("%s\n", "** AFTER **");
@@ -1000,7 +1000,7 @@ test_skiplist_delete_single_several(
 	int i;
 
 	for (i = 101; i < 120; i++) {
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &i, value);
+		ion_status_t status = sl_insert(&skiplist, &i, value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1028,7 +1028,7 @@ test_skiplist_delete_single_several(
 	/* After this block, "theone" is undefined, freed memory and should not
 	 * be accessed. */
 	int				key		= 112;
-	ion_status_t	status	= sl_delete(&skiplist, (ion_key_t) &key);
+	ion_status_t	status	= sl_delete(&skiplist, &key);
 
 #if DEBUG
 	printf("%s\n", "** AFTER **");
@@ -1072,7 +1072,7 @@ test_skiplist_delete_single_several_noncont(
 	int i;
 
 	for (i = 230; i < 300; i += 5) {
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &i, value);
+		ion_status_t status = sl_insert(&skiplist, &i, value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1100,7 +1100,7 @@ test_skiplist_delete_single_several_noncont(
 	/* After this block, "theone" is undefined, freed memory and should not
 	 * be accessed. */
 	int				key		= 240;
-	ion_status_t	status	= sl_delete(&skiplist, (ion_key_t) &key);
+	ion_status_t	status	= sl_delete(&skiplist, &key);
 
 #if DEBUG
 	printf("%s\n", "** AFTER **");
@@ -1142,7 +1142,7 @@ test_skiplist_delete_several_all(
 	int i;
 
 	for (i = 9; i < 99; i += 3) {
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &i, value);
+		ion_status_t status = sl_insert(&skiplist, &i, value);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1154,7 +1154,7 @@ test_skiplist_delete_several_all(
 #endif
 
 	for (i = 9; i < 99; i += 3) {
-		ion_status_t status = sl_delete(&skiplist, (ion_key_t) &i);
+		ion_status_t status = sl_delete(&skiplist, &i);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1192,7 +1192,7 @@ test_skiplist_update_single_nonexist(
 
 	initialize_skiplist_std_conditions(&skiplist);
 
-	ion_status_t status = sl_update(&skiplist, IONIZE(72, int), (ion_value_t) (char *) { "test val" });
+	ion_status_t status = sl_update(&skiplist, IONIZE(72, int), (char *) { "test val" });
 
 #if DEBUG
 	print_skiplist(&skip_list);
@@ -1224,7 +1224,7 @@ test_skiplist_update_single_nonexist_nonempty(
 
 	initialize_skiplist_std_conditions(&skiplist);
 
-	ion_status_t status = sl_insert(&skiplist, IONIZE(99, int), (ion_value_t) (char *) { "not val" });
+	ion_status_t status = sl_insert(&skiplist, IONIZE(99, int), (char *) { "not val" });
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1234,7 +1234,7 @@ test_skiplist_update_single_nonexist_nonempty(
 	print_skiplist(&skip_list);
 #endif
 
-	status = sl_update(&skiplist, IONIZE(13, int), (ion_value_t) (char *) { "test val" });
+	status = sl_update(&skiplist, IONIZE(13, int), (char *) { "test val" });
 
 #if DEBUG
 	printf("%s\n", "** AFTER **");
@@ -1270,7 +1270,7 @@ test_skiplist_update_many_nonexist_nonempty(
 	int i;
 
 	for (i = 30; i < 40; i += 2) {
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &i, (ion_value_t) (char *) { "not it!" });
+		ion_status_t status = sl_insert(&skiplist, &i, (char *) { "not it!" });
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1281,7 +1281,7 @@ test_skiplist_update_many_nonexist_nonempty(
 	print_skiplist(&skip_list);
 #endif
 
-	ion_status_t status = sl_update(&skiplist, IONIZE(45, int), (ion_value_t) (char *) { "test val" });
+	ion_status_t status = sl_update(&skiplist, IONIZE(45, int), (char *) { "test val" });
 
 #if DEBUG
 	printf("%s\n", "** AFTER **");
@@ -1317,7 +1317,7 @@ test_skiplist_update_single_exist(
 
 	initialize_skiplist_std_conditions(&skiplist);
 
-	ion_status_t status = sl_insert(&skiplist, IONIZE(45, int), (ion_value_t) (char *) { "old val" });
+	ion_status_t status = sl_insert(&skiplist, IONIZE(45, int), (char *) { "old val" });
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1327,7 +1327,7 @@ test_skiplist_update_single_exist(
 	print_skiplist(&skip_list);
 #endif
 
-	status = sl_update(&skiplist, IONIZE(45, int), (ion_value_t) (char *) { "new val" });
+	status = sl_update(&skiplist, IONIZE(45, int), (char *) { "new val" });
 
 #if DEBUG
 	printf("%s\n", "** AFTER **");
@@ -1364,7 +1364,7 @@ test_skiplist_update_single_many_exist(
 	int i;
 
 	for (i = 20; i < 46; i += 2) {
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &i, (ion_value_t) (char *) { "MATH" });
+		ion_status_t status = sl_insert(&skiplist, &i, (char *) { "MATH" });
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1375,7 +1375,7 @@ test_skiplist_update_single_many_exist(
 	print_skiplist(&skip_list);
 #endif
 
-	ion_status_t status = sl_update(&skiplist, IONIZE(30, int), (ion_value_t) (char *) { "COSC" });
+	ion_status_t status = sl_update(&skiplist, IONIZE(30, int), (char *) { "COSC" });
 
 #if DEBUG
 	printf("%s\n", "** AFTER **");
@@ -1414,7 +1414,7 @@ test_skiplist_update_several_many_exist(
 	int i;
 
 	for (i = 60; i < 99; i += 3) {
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &i, (ion_value_t) (char *) { "TEST" });
+		ion_status_t status = sl_insert(&skiplist, &i, (char *) { "TEST" });
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1426,9 +1426,9 @@ test_skiplist_update_several_many_exist(
 #endif
 
 	for (i = 60; i < 99; i += 3) {
-		ion_status_t status = sl_update(&skiplist, (ion_key_t) &i, (ion_value_t) (char *) { "VALUE" });
+		ion_status_t status = sl_update(&skiplist, &i, (char *) { "VALUE" });
 
-		ion_sl_node_t *cursor	= sl_find_node(&skiplist, (ion_key_t) &i);
+		ion_sl_node_t *cursor	= sl_find_node(&skiplist, &i);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1465,7 +1465,7 @@ test_skiplist_update_several_same_key(
 	int i;
 
 	for (i = 0; i < 100; i++) {
-		ion_status_t status = sl_insert(&skiplist, IONIZE(64, int), (ion_value_t) (char *) { "samez U" });
+		ion_status_t status = sl_insert(&skiplist, IONIZE(64, int), (char *) { "samez U" });
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1476,7 +1476,7 @@ test_skiplist_update_several_same_key(
 	print_skiplist(&skip_list);
 #endif
 
-	ion_status_t status = sl_update(&skiplist, IONIZE(64, int), (ion_value_t) (char *) { "new same" });
+	ion_status_t status = sl_update(&skiplist, IONIZE(64, int), (char *) { "new same" });
 
 #if DEBUG
 	printf("%s\n", "** UPDATE **");
@@ -1514,25 +1514,25 @@ test_skiplist_update_several_same_key_in_mix(
 
 	initialize_skiplist_std_conditions(&skiplist);
 
-	sl_insert(&skiplist, IONIZE(32, int), (ion_value_t) (char *) { "samez U" });
-	sl_insert(&skiplist, IONIZE(33, int), (ion_value_t) (char *) { "samez U" });
-	sl_insert(&skiplist, IONIZE(35, int), (ion_value_t) (char *) { "samez U" });
+	sl_insert(&skiplist, IONIZE(32, int), (char *) { "samez U" });
+	sl_insert(&skiplist, IONIZE(33, int), (char *) { "samez U" });
+	sl_insert(&skiplist, IONIZE(35, int), (char *) { "samez U" });
 
 	int i;
 
 	for (i = 0; i < 100; i++) {
-		sl_insert(&skiplist, IONIZE(55, int), (ion_value_t) (char *) { "samez  U" });
+		sl_insert(&skiplist, IONIZE(55, int), (char *) { "samez  U" });
 	}
 
-	sl_insert(&skiplist, IONIZE(100, int), (ion_value_t) (char *) { "samez U" });
-	sl_insert(&skiplist, IONIZE(101, int), (ion_value_t) (char *) { "samez U" });
+	sl_insert(&skiplist, IONIZE(100, int), (char *) { "samez U" });
+	sl_insert(&skiplist, IONIZE(101, int), (char *) { "samez U" });
 
 #if DEBUG
 	printf("%s\n", "** INSERT **");
 	print_skiplist(&skip_list);
 #endif
 
-	ion_status_t status = sl_update(&skiplist, IONIZE(55, int), (ion_value_t) (char *) { "new same" });
+	ion_status_t status = sl_update(&skiplist, IONIZE(55, int), (char *) { "new same" });
 
 #if DEBUG
 	printf("%s\n", "** UPDATE **");
@@ -1570,7 +1570,7 @@ test_skiplist_delete_then_insert_single(
 
 	initialize_skiplist_std_conditions(&skiplist);
 
-	ion_status_t status = sl_insert(&skiplist, IONIZE(66, int), (ion_value_t) (char *) { "toaster" });
+	ion_status_t status = sl_insert(&skiplist, IONIZE(66, int), (char *) { "toaster" });
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1590,7 +1590,7 @@ test_skiplist_delete_then_insert_single(
 	print_skiplist(&skip_list);
 #endif
 
-	status = sl_insert(&skiplist, IONIZE(365, int), (ion_value_t) (char *) { "potato" });
+	status = sl_insert(&skiplist, IONIZE(365, int), (char *) { "potato" });
 
 #if DEBUG
 	printf("%s\n", "** REINSERT **");
@@ -1628,7 +1628,7 @@ test_skiplist_delete_then_insert_several(
 	int i;
 
 	for (i = 0; i < 50; i++) {
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &i, (ion_value_t) (char *) { "cake" });
+		ion_status_t status = sl_insert(&skiplist, &i, (char *) { "cake" });
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1640,7 +1640,7 @@ test_skiplist_delete_then_insert_several(
 #endif
 
 	for (i = 0; i < 50; i++) {
-		ion_status_t status = sl_delete(&skiplist, (ion_key_t) &i);
+		ion_status_t status = sl_delete(&skiplist, &i);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1652,7 +1652,7 @@ test_skiplist_delete_then_insert_several(
 #endif
 
 	for (i = 50; i < 100; i++) {
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &i, (ion_value_t) (char *) { "pie" });
+		ion_status_t status = sl_insert(&skiplist, &i, (char *) { "pie" });
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1694,7 +1694,7 @@ test_skiplist_delete_several_same_key(
 	int i;
 
 	for (i = 0; i < 100; i++) {
-		ion_status_t status = sl_insert(&skiplist, IONIZE(64, int), (ion_value_t) (char *) { "samez" });
+		ion_status_t status = sl_insert(&skiplist, IONIZE(64, int), (char *) { "samez" });
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
@@ -1742,18 +1742,18 @@ test_skiplist_delete_several_same_key_in_mix(
 
 	initialize_skiplist_std_conditions(&skiplist);
 
-	sl_insert(&skiplist, IONIZE(32, int), (ion_value_t) (char *) { "samez" });
-	sl_insert(&skiplist, IONIZE(33, int), (ion_value_t) (char *) { "samez" });
-	sl_insert(&skiplist, IONIZE(35, int), (ion_value_t) (char *) { "samez" });
+	sl_insert(&skiplist, IONIZE(32, int), (char *) { "samez" });
+	sl_insert(&skiplist, IONIZE(33, int), (char *) { "samez" });
+	sl_insert(&skiplist, IONIZE(35, int), (char *) { "samez" });
 
 	int i;
 
 	for (i = 0; i < 100; i++) {
-		sl_insert(&skiplist, IONIZE(55, int), (ion_value_t) (char *) { "samez" });
+		sl_insert(&skiplist, IONIZE(55, int), (char *) { "samez" });
 	}
 
-	sl_insert(&skiplist, IONIZE(100, int), (ion_value_t) (char *) { "samez" });
-	sl_insert(&skiplist, IONIZE(101, int), (ion_value_t) (char *) { "samez" });
+	sl_insert(&skiplist, IONIZE(100, int), (char *) { "samez" });
+	sl_insert(&skiplist, IONIZE(101, int), (char *) { "samez" });
 
 #if DEBUG
 	printf("%s\n", "** INSERT **");
@@ -1806,9 +1806,9 @@ test_skiplist_different_size(
 
 	initialize_skiplist(&skiplist, key_type, compare, maxheight, key_size, value_size, pnum, pden);
 
-	sl_insert(&skiplist, (ion_key_t) &(long long) { 64 }, (ion_value_t) (char *) { "pop" });
-	sl_insert(&skiplist, (ion_key_t) &(long long) { 32 }, (ion_value_t) (char *) { "bep" });
-	sl_insert(&skiplist, (ion_key_t) &(long long) { 16 }, (ion_value_t) (char *) { "tot" });
+	sl_insert(&skiplist, &(long long) { 64 }, (char *) { "pop" });
+	sl_insert(&skiplist, &(long long) { 32 }, (char *) { "bep" });
+	sl_insert(&skiplist, &(long long) { 16 }, (char *) { "tot" });
 
 #if DEBUG
 	printf("%s\n", "** INSERT **");
@@ -1832,30 +1832,30 @@ test_skiplist_different_size(
 	ion_byte_t		value[10];
 	ion_status_t	status;
 
-	status = sl_query(&skiplist, (ion_key_t) &(long long) { 64 }, value);
+	status = sl_query(&skiplist, &(long long) { 64 }, value);
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	PLANCK_UNIT_ASSERT_STR_ARE_EQUAL(tc, (char *) value, "pop");
 
-	status = sl_query(&skiplist, (ion_key_t) &(long long) { 32 }, value);
+	status = sl_query(&skiplist, &(long long) { 32 }, value);
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	PLANCK_UNIT_ASSERT_STR_ARE_EQUAL(tc, (char *) value, "bep");
 
-	status = sl_query(&skiplist, (ion_key_t) &(long long) { 16 }, value);
+	status = sl_query(&skiplist, &(long long) { 16 }, value);
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	PLANCK_UNIT_ASSERT_STR_ARE_EQUAL(tc, (char *) value, "tot");
 
-	status = sl_delete(&skiplist, (ion_key_t) &(long long) { 64 });
+	status = sl_delete(&skiplist, &(long long) { 64 });
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
-	status = sl_delete(&skiplist, (ion_key_t) &(long long) { 32 });
+	status = sl_delete(&skiplist, &(long long) { 32 });
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
-	status = sl_delete(&skiplist, (ion_key_t) &(long long) { 16 });
+	status = sl_delete(&skiplist, &(long long) { 16 });
 	PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 	PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 
@@ -1888,14 +1888,14 @@ test_skiplist_big_keys(
 	int i;
 
 	for (i = 900; i < 999; i++) {
-		ion_status_t status = sl_insert(&skiplist, (ion_key_t) &i, (ion_value_t) (char *) { "BIG!" });
+		ion_status_t status = sl_insert(&skiplist, &i, (char *) { "BIG!" });
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);
 	}
 
 	for (i = 900; i < 999; i++) {
-		ion_sl_node_t *cursor = sl_find_node(&skiplist, (ion_key_t) &i);
+		ion_sl_node_t *cursor = sl_find_node(&skiplist, &i);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, *(int *) cursor->key == i);
 		PLANCK_UNIT_ASSERT_STR_ARE_EQUAL(tc, (char *) cursor->value, "BIG!");
@@ -1907,7 +1907,7 @@ test_skiplist_big_keys(
 #endif
 
 	for (i = 900; i < 999; i++) {
-		ion_status_t status = sl_delete(&skiplist, (ion_key_t) &i);
+		ion_status_t status = sl_delete(&skiplist, &i);
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, err_ok == status.error);
 		PLANCK_UNIT_ASSERT_TRUE(tc, 1 == status.count);

--- a/src/tests/unit/dictionary/skip_list/test_skip_list_handler.c
+++ b/src/tests/unit/dictionary/skip_list/test_skip_list_handler.c
@@ -43,13 +43,13 @@ create_test_dictionary(
 
 	/* First insert one of each element, up to half... */
 	for (i = 0; i < half_elements; i++) {
-		dictionary_insert(dictionary, (ion_key_t) &i, (ion_value_t) value);
+		dictionary_insert(dictionary, &i, value);
 	}
 
 	/* Continue inserting, this time with an increasing amount of duplicates */
 	for (; i < num_elements; i++) {
 		for (j = 0; j < num_duplicates; j++) {
-			dictionary_insert(dictionary, (ion_key_t) &i, (ion_value_t) value);
+			dictionary_insert(dictionary, &i, value);
 		}
 
 		/* Each time we increment the key, add one more duplicate */
@@ -213,11 +213,11 @@ test_slhandler_cursor_equality_with_results(
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, cs_cursor_active == c_status);
 	PLANCK_UNIT_ASSERT_TRUE(tc, dict.instance->compare(record.key, IONIZE(26, int), dict.instance->record.key_size) == 0);
-	PLANCK_UNIT_ASSERT_TRUE(tc, memcmp(record.value, (ion_value_t) (char *) { "DATA" }, dict.instance->record.value_size) == 0);
+	PLANCK_UNIT_ASSERT_TRUE(tc, memcmp(record.value, (char *) { "DATA" }, dict.instance->record.value_size) == 0);
 
 	while (c_status != cs_end_of_results) {
 		PLANCK_UNIT_ASSERT_TRUE(tc, dict.instance->compare(record.key, IONIZE(26, int), dict.instance->record.key_size) == 0);
-		PLANCK_UNIT_ASSERT_TRUE(tc, memcmp(record.value, (ion_value_t) (char *) { "DATA" }, dict.instance->record.value_size) == 0);
+		PLANCK_UNIT_ASSERT_TRUE(tc, memcmp(record.value, (char *) { "DATA" }, dict.instance->record.value_size) == 0);
 		c_status = cursor->next(cursor, &record);
 	}
 
@@ -303,12 +303,12 @@ test_slhandler_cursor_range_with_results(
 	PLANCK_UNIT_ASSERT_TRUE(tc, cs_cursor_active == c_status);
 	PLANCK_UNIT_ASSERT_TRUE(tc, dict.instance->compare(record.key, IONIZE(5, int), dict.instance->record.key_size) >= 0);
 	PLANCK_UNIT_ASSERT_TRUE(tc, dict.instance->compare(record.key, IONIZE(78, int), dict.instance->record.key_size) <= 0);
-	PLANCK_UNIT_ASSERT_TRUE(tc, memcmp(record.value, (ion_value_t) (char *) { "DATA" }, dict.instance->record.value_size) == 0);
+	PLANCK_UNIT_ASSERT_TRUE(tc, memcmp(record.value, (char *) { "DATA" }, dict.instance->record.value_size) == 0);
 
 	while (c_status != cs_end_of_results) {
 		PLANCK_UNIT_ASSERT_TRUE(tc, dict.instance->compare(record.key, IONIZE(5, int), dict.instance->record.key_size) >= 0);
 		PLANCK_UNIT_ASSERT_TRUE(tc, dict.instance->compare(record.key, IONIZE(78, int), dict.instance->record.key_size) <= 0);
-		PLANCK_UNIT_ASSERT_TRUE(tc, memcmp(record.value, (ion_value_t) (char *) { "DATA" }, dict.instance->record.value_size) == 0);
+		PLANCK_UNIT_ASSERT_TRUE(tc, memcmp(record.value, (char *) { "DATA" }, dict.instance->record.value_size) == 0);
 		c_status = cursor->next(cursor, &record);
 	}
 
@@ -364,12 +364,12 @@ test_slhandler_cursor_range_lower_missing(
 	PLANCK_UNIT_ASSERT_TRUE(tc, cs_cursor_active == c_status);
 	PLANCK_UNIT_ASSERT_TRUE(tc, dict.instance->compare(record.key, IONIZE(-50, int), dict.instance->record.key_size) >= 0);
 	PLANCK_UNIT_ASSERT_TRUE(tc, dict.instance->compare(record.key, IONIZE(50, int), dict.instance->record.key_size) <= 0);
-	PLANCK_UNIT_ASSERT_TRUE(tc, memcmp(record.value, (ion_value_t) (char *) { "DATA" }, dict.instance->record.value_size) == 0);
+	PLANCK_UNIT_ASSERT_TRUE(tc, memcmp(record.value, (char *) { "DATA" }, dict.instance->record.value_size) == 0);
 
 	while (c_status != cs_end_of_results) {
 		PLANCK_UNIT_ASSERT_TRUE(tc, dict.instance->compare(record.key, IONIZE(-50, int), dict.instance->record.key_size) >= 0);
 		PLANCK_UNIT_ASSERT_TRUE(tc, dict.instance->compare(record.key, IONIZE(50, int), dict.instance->record.key_size) <= 0);
-		PLANCK_UNIT_ASSERT_TRUE(tc, memcmp(record.value, (ion_value_t) (char *) { "DATA" }, dict.instance->record.value_size) == 0);
+		PLANCK_UNIT_ASSERT_TRUE(tc, memcmp(record.value, (char *) { "DATA" }, dict.instance->record.value_size) == 0);
 		c_status = cursor->next(cursor, &record);
 	}
 
@@ -438,7 +438,7 @@ test_slhandler_cursor_range_exact_results(
 		int expected_key = extra_keys[key_idx];
 
 		PLANCK_UNIT_ASSERT_TRUE(tc, dict.instance->compare(record.key, &expected_key, dict.instance->record.key_size) == 0);
-		PLANCK_UNIT_ASSERT_TRUE(tc, memcmp(record.value, (ion_value_t) (char *) { "test" }, dict.instance->record.value_size) == 0);
+		PLANCK_UNIT_ASSERT_TRUE(tc, memcmp(record.value, (char *) { "test" }, dict.instance->record.value_size) == 0);
 		c_status = cursor->next(cursor, &record);
 		key_idx++;
 	}

--- a/src/tests/unit/dictionary/test_dictionary.c
+++ b/src/tests/unit/dictionary/test_dictionary.c
@@ -14,28 +14,28 @@ test_dictionary_compare_numerics(
 	ion_key_t	key_one;
 	ion_key_t	key_two;
 
-	key_one = (ion_key_t) &(int) {
+	key_one = &(int) {
 		1
 	};
-	key_two = (ion_key_t) &(int) {
+	key_two = &(int) {
 		1
 	};
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, IS_EQUAL == dictionary_compare_signed_value(key_one, key_two, sizeof(int)));
 
-	key_one = (ion_key_t) &(int) {
+	key_one = &(int) {
 		1
 	};
-	key_two = (ion_key_t) &(int) {
+	key_two = &(int) {
 		2
 	};
 
 	PLANCK_UNIT_ASSERT_TRUE(tc, ZERO > dictionary_compare_signed_value(key_one, key_two, sizeof(int)));
 
-	key_one = (ion_key_t) &(int) {
+	key_one = &(int) {
 		2
 	};
-	key_two = (ion_key_t) &(int) {
+	key_two = &(int) {
 		0
 	};
 
@@ -44,7 +44,7 @@ test_dictionary_compare_numerics(
 	int i;
 
 	for (i = 1; i < 10; i++) {
-		PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_signed_value((ion_key_t) &i, key_two, sizeof(int)));
+		PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_signed_value(&i, key_two, sizeof(int)));
 	}
 
 	/* case for unsigned signed char */
@@ -75,7 +75,7 @@ test_dictionary_compare_numerics(
 			0
 		};
 
-		PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_unsigned_value((ion_key_t) key_one, (ion_key_t) key_two, sizeof(unsigned short)));
+		PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_unsigned_value(key_one, key_two, sizeof(unsigned short)));
 	}
 
 	{
@@ -89,7 +89,7 @@ test_dictionary_compare_numerics(
 			0
 		};
 
-		PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_unsigned_value((ion_key_t) key_one, (ion_key_t) key_two, sizeof(unsigned int)));
+		PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_unsigned_value(key_one, key_two, sizeof(unsigned int)));
 	}
 
 	{
@@ -103,7 +103,7 @@ test_dictionary_compare_numerics(
 			0
 		};
 
-		PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_unsigned_value((ion_key_t) key_one, (ion_key_t) key_two, sizeof(unsigned long)));
+		PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_unsigned_value(key_one, key_two, sizeof(unsigned long)));
 	}
 
 	{
@@ -117,7 +117,7 @@ test_dictionary_compare_numerics(
 			0
 		};
 
-		PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_signed_value((ion_key_t) key_one, (ion_key_t) key_two, sizeof(long)));
+		PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_signed_value(key_one, key_two, sizeof(long)));
 	}
 	{
 		char	*key_one;
@@ -130,7 +130,7 @@ test_dictionary_compare_numerics(
 			0
 		};
 
-		PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_signed_value((ion_key_t) key_one, (ion_key_t) key_two, sizeof(char)));
+		PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_signed_value(key_one, key_two, sizeof(char)));
 	}
 
 	{
@@ -144,7 +144,7 @@ test_dictionary_compare_numerics(
 			-1
 		};
 
-		PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_signed_value((ion_key_t) key_one, (ion_key_t) key_two, sizeof(char)));
+		PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_signed_value(key_one, key_two, sizeof(char)));
 	}
 
 	{
@@ -159,13 +159,13 @@ test_dictionary_compare_numerics(
 		for (i = SHRT_MIN / 10; i < SHRT_MAX / 10; i++) {
 			for (j = SHRT_MIN / 10; j < SHRT_MAX / 10; j++) {
 				if (i < j) {
-					PLANCK_UNIT_ASSERT_TRUE(tc, ZERO > dictionary_compare_signed_value((ion_key_t) key_one, (ion_key_t) key_two, sizeof(short)));
+					PLANCK_UNIT_ASSERT_TRUE(tc, ZERO > dictionary_compare_signed_value(key_one, key_two, sizeof(short)));
 				}
 				else if (i == j) {
-					PLANCK_UNIT_ASSERT_TRUE(tc, ZERO == dictionary_compare_signed_value((ion_key_t) key_one, (ion_key_t) key_two, sizeof(short)));
+					PLANCK_UNIT_ASSERT_TRUE(tc, ZERO == dictionary_compare_signed_value(key_one, key_two, sizeof(short)));
 				}
 				else {
-					PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_signed_value((ion_key_t) key_one, (ion_key_t) key_two, sizeof(short)));
+					PLANCK_UNIT_ASSERT_TRUE(tc, ZERO < dictionary_compare_signed_value(key_one, key_two, sizeof(short)));
 				}
 			}
 		}


### PR DESCRIPTION
Remove unnecessary casts in code

Remaining casts are generally required for function calls or helpful for readability