### PR TITLE
Include fdeleteall() where necessary

### DIFF
--- a/src/tests/behaviour/dictionary/bpp_tree/test_behaviour_bpp_tree.c
+++ b/src/tests/behaviour/dictionary/bpp_tree/test_behaviour_bpp_tree.c
@@ -30,5 +30,6 @@ void
 runalltests_behaviour_bpp_tree(
 	void
 ) {
+	fdeleteall();
 	bhdct_run_tests(bpptree_init, -1, ION_BHDCT_ALL_TESTS & ~ION_BHDCT_STRING_INT);
 }

--- a/src/tests/behaviour/dictionary/open_address_file_hash/test_behaviour_open_address_file_hash.c
+++ b/src/tests/behaviour/dictionary/open_address_file_hash/test_behaviour_open_address_file_hash.c
@@ -30,5 +30,6 @@ void
 runalltests_behaviour_open_address_file_hash(
 	void
 ) {
+	fdeleteall();
 	bhdct_run_tests(oafdict_init, 200, ION_BHDCT_ALL_TESTS & ~ION_BHDCT_DUPLICATES);
 }

--- a/src/tests/behaviour/dictionary/open_address_hash/test_behaviour_open_address_hash.c
+++ b/src/tests/behaviour/dictionary/open_address_hash/test_behaviour_open_address_hash.c
@@ -30,5 +30,6 @@ void
 runalltests_behaviour_open_address_hash(
 	void
 ) {
+	fdeleteall();
 	bhdct_run_tests(oadict_init, 200, ION_BHDCT_ALL_TESTS & ~ION_BHDCT_DUPLICATES);
 }

--- a/src/tests/behaviour/dictionary/skip_list/test_behaviour_skip_list.c
+++ b/src/tests/behaviour/dictionary/skip_list/test_behaviour_skip_list.c
@@ -31,6 +31,7 @@ runalltests_behaviour_skip_list(
 	void
 ) {
 #if defined(ARDUINO)
+	fdeleteall();
 	bhdct_run_tests(sldict_init, 7, ION_BHDCT_ALL_TESTS & ~ION_BHDCT_STRING_INT);
 #else
 	bhdct_run_tests(sldict_init, 7, ION_BHDCT_ALL_TESTS);

--- a/src/tests/unit/cpp_wrapper/test_cpp_wrapper.cpp
+++ b/src/tests/unit/cpp_wrapper/test_cpp_wrapper.cpp
@@ -1186,6 +1186,8 @@ cpp_wrapper_getsuite_2(
 void
 runalltests_cpp_wrapper(
 ) {
+	fdeleteall();
+
 	planck_unit_suite_t *suite1 = cpp_wrapper_getsuite_1();
 
 	planck_unit_run_suite(suite1);

--- a/src/tests/unit/dictionary/bpp_tree/run_bpp_tree.c
+++ b/src/tests/unit/dictionary/bpp_tree/run_bpp_tree.c
@@ -4,6 +4,7 @@ int
 main(
 	void
 ) {
+	fdeleteall();
 	run_all_tests_bpptreehandler();
 	return 0;
 }

--- a/src/tests/unit/dictionary/flat_file/run_flat_file.c
+++ b/src/tests/unit/dictionary/flat_file/run_flat_file.c
@@ -4,6 +4,7 @@
 int
 main(
 ) {
+	fdeleteall();
 	runalltests_flat_file();
 	runalltests_flat_file_handler();
 	return 0;

--- a/src/tests/unit/dictionary/open_address_file_hash/run_open_address_file_hash.c
+++ b/src/tests/unit/dictionary/open_address_file_hash/run_open_address_file_hash.c
@@ -4,6 +4,7 @@
 int
 main(
 ) {
+	fdeleteall();
 	runalltests_open_address_file_hash();
 	runalltests_open_address_file_hash_handler();
 	return 0;

--- a/src/tests/unit/dictionary/open_address_hash/run_open_address_hash.c
+++ b/src/tests/unit/dictionary/open_address_hash/run_open_address_hash.c
@@ -4,6 +4,7 @@
 int
 main(
 ) {
+	fdeleteall();
 	runalltests_open_address_hash();
 	runalltests_open_address_hash_handler();
 	return 0;

--- a/src/tests/unit/dictionary/run_dictionary.c
+++ b/src/tests/unit/dictionary/run_dictionary.c
@@ -3,6 +3,7 @@
 int
 main(
 ) {
+	fdeleteall();
 	runalltests_dictionary();
 	return 0;
 }

--- a/src/tests/unit/dictionary/skip_list/run_skip_list.c
+++ b/src/tests/unit/dictionary/skip_list/run_skip_list.c
@@ -13,6 +13,7 @@ int
 main(
 	void
 ) {
+	fdeleteall();
 	runalltests_skiplist();
 	runalltests_skiplist_handler();
 	return 0;

--- a/src/tests/unit/iinq/run_iinq.c
+++ b/src/tests/unit/iinq/run_iinq.c
@@ -4,6 +4,7 @@ int
 main(
 	void
 ) {
+	fdeleteall();
 	run_all_tests_iinq();
 	return 0;
 }


### PR DESCRIPTION
fdeleteall() is now included for all tests that require Arduino SD card usability.