### PR TITLE
Update bpp_tree.c

### DIFF
--- a/src/dictionary/bpp_tree/bpp_tree.c
+++ b/src/dictionary/bpp_tree/bpp_tree.c
@@ -426,6 +426,8 @@ search(
 					case MODE_FIRST:
 						/* backtrack to first key */
 						ub			= m - 1;
+						if (lb > ub)
+                            				return ION_CC_EQ;
 						foundDup	= boolean_true;
 						break;
 


### PR DESCRIPTION
If search called on node looking for MODE_FIRST key, and the first key is at index 0, index 1 is returned in error.

Algorithms intent was to "backtrack" so once surpassed the index +1 would result in the first key. This works except when desired key is at index 0, so no need to back track.

Issue with duplicate keys only