### PR TITLE
Create new examples for IonDB Arduino library

### DIFF
--- a/examples/FileBasedUsage/FileBasedUsage.ino
+++ b/examples/FileBasedUsage/FileBasedUsage.ino
@@ -1,12 +1,14 @@
+#include <SD.h>
 #include <IonDB.h>
 
 void
 setup(
 ) {
+	SD.begin(13);
 	Serial.begin(9600);
 
 	/* Instantiate your dictionary */
-	Dictionary < int, int > *dict = new SkipList < int, int > (-1, key_type_numeric_signed, sizeof(int), sizeof(int), 7);
+	Dictionary < int, int > *dict = new FlatFile < int, int > (-1, key_type_numeric_signed, sizeof(int), sizeof(int), 7);
 
 	/* Insert a record with key 3 and value 10 */
 	dict->insert(3, 10);

--- a/examples/FileBasedUsage/FileBasedUsage.ino
+++ b/examples/FileBasedUsage/FileBasedUsage.ino
@@ -4,7 +4,7 @@
 void
 setup(
 ) {
-	SD.begin(13);
+	SD.begin(4);
 	Serial.begin(9600);
 
 	/* Instantiate your dictionary */

--- a/examples/StringUsage/StringUsage.ino
+++ b/examples/StringUsage/StringUsage.ino
@@ -39,7 +39,8 @@ setup(
     /* Cast the returned value to type String using Arduino String constructor */
     String new_string = String((char *) new_value);
 
-    printf("3 -> %d\n", new_string);
+    printf("3 -> ");
+    Serial.println(new_string);
 
 	/* Always clean up your dictionaries when you're done with them! */
 	delete dict;

--- a/examples/StringUsage/StringUsage.ino
+++ b/examples/StringUsage/StringUsage.ino
@@ -1,0 +1,50 @@
+#include <IonDB.h>
+
+/* This example outlines how to use Arduino String objects as keys or values with IonDB.
+   This sketch exemplifies the use of Arduino Strings as values. */
+
+void
+setup(
+) {
+	Serial.begin(9600);
+
+	/* Instantiate your dictionary of key type int and value type ion_value_t */
+	Dictionary < int, ion_value_t > *dict = new SkipList < int, ion_value_t > (-1, key_type_numeric_signed, sizeof(int), sizeof("one"), 7);
+
+	/* Insert a record with key 3 and value "one" */
+	dict->insert(3, "one");
+
+	dict->insert(4, "two");
+    dict->insert(9, "six");
+    dict->insert(42, "ten");
+
+	/* Retrieve a value of type ion_value_t by providing a key */
+	ion_value_t  my_value = dict->get(3);
+
+	/* Cast the returned value to type String using Arduino String constructor */
+    String string_value = String((char *) my_value);
+
+	/* You should check the status on every operation to ensure good data integrity */
+	if (err_ok != dict->last_status.error) {
+		printf("Oh no! Something went wrong with my get operation\n");
+	}
+
+	printf("3 -> ");
+    Serial.println(string_value);
+
+    /* Update the value stored at a key */
+    dict->update(3, "new");
+    ion_value_t new_value = dict->get(3);
+
+    /* Cast the returned value to type String using Arduino String constructor */
+    String new_string = String((char *) new_value);
+
+    printf("3 -> %d\n", new_string);
+
+	/* Always clean up your dictionaries when you're done with them! */
+	delete dict;
+}
+
+void
+loop(
+) {}

--- a/examples/UserDefinedTypes/UserDefinedTypes.ino
+++ b/examples/UserDefinedTypes/UserDefinedTypes.ino
@@ -1,0 +1,76 @@
+#include <IonDB.h>
+
+/* This example outlines how to use IonDB with user-defined (or non-C++ compliant)
+   key or value types. For this example, the value type is a user-defined struct.
+   For more examples of using non-C++ compliant key or value types, please see
+   the example StringUsage. */
+
+void
+setup(
+) {
+  Serial.begin(9600);
+
+  /* Create sample object */
+  struct obj {
+    String message;
+    int num;
+  };
+
+  /* Create an instance of the object */
+  obj ex = {"hi", 1};
+
+  /* Copy the object to a char array for insertion */
+  char bytes[sizeof(ex)];
+  memcpy(bytes, &ex, sizeof(ex));
+
+  /* Instantiate your dictionary of key type int and value type ion_value_t */
+  Dictionary < int, ion_value_t > *dict = new SkipList < int, ion_value_t > (-1, key_type_numeric_signed, sizeof(int), sizeof(bytes), 7);
+
+  /* Insert a record with key 3 and value ("hi", 1) */
+  dict->insert(1, bytes);
+
+  /* Retrieve a value of type ion_value_t by providing a key */
+  ion_value_t  my_value = dict->get(1);
+
+  /* Copy returned value back into struct object */
+  obj ret_struct;
+  memcpy(&ret_struct, my_value, sizeof(ret_struct));
+
+  /* You should check the status on every operation to ensure good data integrity */
+  if (err_ok != dict->last_status.error) {
+    printf("Oh no! Something went wrong with my get operation\n");
+  }
+
+  /* Print returned struct values */
+  printf("1 -> \nMessage: ");
+  Serial.println(String(ret_struct.message));
+  printf("Num: %i\n", (int) ret_struct.num);
+
+  /* Update the value stored at a key */
+  obj new_ex = {"bye", 2};
+
+  /* Copy the object to a char array for insertion */
+  char new_bytes[sizeof(new_ex)];
+  memcpy(new_bytes, &new_ex, sizeof(new_ex));
+
+  dict->update(1, new_bytes);
+
+  /* Return new updated value */
+  ion_value_t new_value = dict->get(1);
+
+  /* Copy returned value back into struct object */
+  obj new_struct;
+  memcpy(&new_struct, new_value, sizeof(new_struct));
+
+  /* Print new returned struct values */
+  printf("1 -> \nMessage: ");
+  Serial.println(String(new_struct.message));
+  printf("Num: %i\n", (int) new_struct.num);
+
+  /* Always clean up your dictionaries when you're done with them! */
+  delete dict;
+}
+
+void
+loop(
+) {}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=IonDB
-version=2.1.2
+version=2.1.4
 author=IonDB Project <iondbproject@gmail.com>
 maintainer=IonDB Project <iondbproject@gmail.com>
 sentence=A powerful key-value store for all data storage needs.

--- a/src/cpp_wrapper/MasterTable.h
+++ b/src/cpp_wrapper/MasterTable.h
@@ -1,9 +1,37 @@
 /******************************************************************************/
 /**
-@file
+@file		MasterTable.h
 @author		Dana Klamut
 @brief		Interface describing how user interacts with the master table using
 			C++.
+@copyright	Copyright 2017
+			The University of British Columbia,
+			IonDB Project Contributors (see AUTHORS.md)
+@par Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+@par 1.Redistributions of source code must retain the above copyright notice,
+	this list of conditions and the following disclaimer.
+
+@par 2.Redistributions in binary form must reproduce the above copyright notice,
+	this list of conditions and the following disclaimer in the documentation
+	and/or other materials provided with the distribution.
+
+@par 3.Neither the name of the copyright holder nor the names of its contributors
+	may be used to endorse or promote products derived from this software without
+	specific prior written permission.
+
+@par THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+	AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+	IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+	ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+	LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+	CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 */
 /******************************************************************************/
 
@@ -349,7 +377,7 @@ deleteDictionary(
 	delete dictionary;
 
 	return ion_delete_from_master_table(id);
-};
+}
 };
 
 #endif /* PROJECT_CPP_MASTERTABLE_H */


### PR DESCRIPTION
These examples include:
* a file-based dictionary creation and usage
* Arduino String values being usage
* user-defined values usage 

BasicUsage.ino was also updated to include dictionary ID in constructor as this was updated in previously in IonDB source files.