### PR TITLE
Fixed arduino fopen to only use append when specified.

### DIFF
--- a/src/file/sd_stdio_c_iface.cpp
+++ b/src/file/sd_stdio_c_iface.cpp
@@ -133,7 +133,7 @@ sd_fopen(
 			SD.remove(filename);
 		}
 
-		operation = FILE_WRITE;
+		operation = (O_WRITE | O_TRUNC | O_CREAT);
 		/* Open a file for update both reading and writing. The file must exist. */
 	}
 	else if (strstr(mode, "r+") != NULL) {
@@ -141,7 +141,7 @@ sd_fopen(
 			return NULL;
 		}
 
-		operation	= FILE_WRITE;
+		operation	= O_RDWR;
 		seek_start	= boolean_true;
 	}
 	/* Create an empty file for both reading and writing. */
@@ -150,10 +150,10 @@ sd_fopen(
 			SD.remove(filename);
 		}
 
-		operation = FILE_WRITE;
+		operation = (O_RDWR | O_CREAT | O_TRUNC);
 	}
 	else if (strcmp(mode, "a+") == 0) {
-		operation = FILE_WRITE;
+		operation = (O_RDWR | O_APPEND | O_CREAT);
 	}
 	else {
 		return 0;	/*incorrect args */


### PR DESCRIPTION
Fixes an issue introduced in the Arduino SD library 1.2.1 where the default mode for FILE_WRITE was changed to append. This broke most file based structures that depended on overwriting.